### PR TITLE
Implement Travis-CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,11 @@ compiler:
   - gcc
   - clang
 
+# Attempt to get the right GCC/Clang versions
+before_script:
+  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  - sudo apt-get update -qq
+  - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
+  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
+  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+


### PR DESCRIPTION
I decided to play with Travis CI today. It's a continuous integration service that builds projects and returns pass/fail status. It has great Github support and will add badges to merge requests and commits letting you know if builds and tests worked properly.

It only took about 20 minutes to read the docs and get it working. You just need to sign into Travis with your Github account and turn on a tick box for this project. If it's okay here, I'll add it to the other projects in the avr-llvm umbrella.

It's fantastic