### PR TITLE
Only build AVR target when going through Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ before_script:
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
+script:
+  - ./configure --enable-targets=avr
+  - make


### PR DESCRIPTION
I haven't tested this, so we'll see with Travis if this will actually work correctly.