### PR TITLE
Create consistent tests for all two-register arithmetic

### DIFF
--- a/test/MC/AVR/inst-adc.s
+++ b/test/MC/AVR/inst-adc.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  adc r12, r3
-  adc r10, r0
-  adc r5,  r4
-  adc r13, r13
+  adc r0,  r15
+  adc r15, r0 
+  adc r16, r31
+  adc r31, r16
 
-; CHECK: adc r12, r3                 ; encoding: [0xc3,0x1c]
-; CHECK: adc r10, r0                 ; encoding: [0xa0,0x1c]
-; CHECK: adc r5, r4                  ; encoding: [0x54,0x1c]
-; CHECK: adc r13, r13                ; encoding: [0xdd,0x1c]
+; CHECK: adc r0,  r15               ; encoding: [0x0f,0x1c]
+; CHECK: adc r15, r0                ; encoding: [0xf0,0x1c]
+; CHECK: adc r16, r31               ; encoding: [0x0f,0x1f]
+; CHECK: adc r31, r16               ; encoding: [0xf0,0x1f]
+

--- a/test/MC/AVR/inst-adc.s
+++ b/test/MC/AVR/inst-adc.s
@@ -3,12 +3,12 @@
 
 foo:
 
-  adc r12, 3
+  adc r12, r3
   adc r10, r0
   adc r5,  r4
   adc r13, r13
 
 ; CHECK: adc r12, r3                 ; encoding: [0xc3,0x1c]
 ; CHECK: adc r10, r0                 ; encoding: [0xa0,0x1c]
-; CHECK: adc r5, r4                  ; encoding: [0x54,0x1e]
+; CHECK: adc r5, r4                  ; encoding: [0x54,0x1c]
 ; CHECK: adc r13, r13                ; encoding: [0xdd,0x1c]

--- a/test/MC/AVR/inst-add.s
+++ b/test/MC/AVR/inst-add.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  add r2, r13
-  add r9, r0
-  add r5, r31
-  add r3, r3
+  add r0,  r15
+  add r15, r0 
+  add r16, r31
+  add r31, r16
 
-; CHECK: add r2, r13                  ; encoding: [0x2d,0x0c]
-; CHECK: add r9, r0                   ; encoding: [0x90,0x0c]
-; CHECK: add r5, r31                  ; encoding: [0x5f,0x0e]
-; CHECK: add r3, r3                   ; encoding: [0x33,0x0c]
+; CHECK: add r0,  r15               ; encoding: [0x0f,0x0c]
+; CHECK: add r15, r0                ; encoding: [0xf0,0x0c]
+; CHECK: add r16, r31               ; encoding: [0x0f,0x0f]
+; CHECK: add r31, r16               ; encoding: [0xf0,0x0f]
+

--- a/test/MC/AVR/inst-and.s
+++ b/test/MC/AVR/inst-and.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  and r30, r2
-  and r1,  r2
-  and r15, r7
-  and r27, r27
+  and r0,  r15
+  and r15, r0 
+  and r16, r31
+  and r31, r16
 
-; CHECK: and r30, r2                  ; encoding: [0xe2,0x21]
-; CHECK: and r1,  r2                  ; encoding: [0x12,0x20]
-; CHECK: and r15, r7                  ; encoding: [0xf7,0x20]
-; CHECK: and r27, r27                 ; encoding: [0xbb,0x23]
+; CHECK: and r0,  r15               ; encoding: [0x0f,0x20]
+; CHECK: and r15, r0                ; encoding: [0xf0,0x20]
+; CHECK: and r16, r31               ; encoding: [0x0f,0x23]
+; CHECK: and r31, r16               ; encoding: [0xf0,0x23]
+

--- a/test/MC/AVR/inst-eor.s
+++ b/test/MC/AVR/inst-eor.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  eor r5,  r7
-  eor r23, r30
-  eor r0,  r14
-  eor r10,  r28
+  eor r0,  r15
+  eor r15, r0 
+  eor r16, r31
+  eor r31, r16
 
-; CHECK: eor r5,  r7                ; encoding: [0x57,0x24]
-; CHECK: eor r23, r30               ; encoding: [0x7e,0x27]
-; CHECK: eor r0,  r14               ; encoding: [0x0e,0x24]
-; CHECK: eor r10, r28               ; encoding: [0xac,0x26]
+; CHECK: eor r0,  r15               ; encoding: [0x0f,0x24]
+; CHECK: eor r15, r0                ; encoding: [0xf0,0x24]
+; CHECK: eor r16, r31               ; encoding: [0x0f,0x27]
+; CHECK: eor r31, r16               ; encoding: [0xf0,0x27]
+

--- a/test/MC/AVR/inst-mul.s
+++ b/test/MC/AVR/inst-mul.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  mul r2, r13
-  mul r9, r0
-  mul r5, r31
-  mul r3, r3
+  mul r0,  r15
+  mul r15, r0 
+  mul r16, r31
+  mul r31, r16
 
-; CHECK: mul r2, r13                  ; encoding: [0x2d,0x9c]
-; CHECK: mul r9, r0                   ; encoding: [0x90,0x9c]
-; CHECK: mul r5, r31                  ; encoding: [0x5f,0x9e]
-; CHECK: mul r3, r3                   ; encoding: [0x33,0x9c]
+; CHECK: mul r0,  r15               ; encoding: [0x0f,0x9c]
+; CHECK: mul r15, r0                ; encoding: [0xf0,0x9c]
+; CHECK: mul r16, r31               ; encoding: [0x0f,0x9f]
+; CHECK: mul r31, r16               ; encoding: [0xf0,0x9f]
+

--- a/test/MC/AVR/inst-or.s
+++ b/test/MC/AVR/inst-or.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  or r31, r12
-  or r12, r13
-  or r0,  r14
-  or r9,  r29
+  or r0,  r15
+  or r15, r0 
+  or r16, r31
+  or r31, r16
 
-; CHECK: or r31, r12                 ; encoding: [0xfc,0x29]
-; CHECK: or r12, r13                 ; encoding: [0xcd,0x28]
-; CHECK: or r0,  r14                 ; encoding: [0x0e,0x28]
-; CHECK: or r9,  r29                 ; encoding: [0x9d,0x2a]
+; CHECK: or r0,  r15               ; encoding: [0x0f,0x28]
+; CHECK: or r15, r0                ; encoding: [0xf0,0x28]
+; CHECK: or r16, r31               ; encoding: [0x0f,0x2b]
+; CHECK: or r31, r16               ; encoding: [0xf0,0x2b]
+

--- a/test/MC/AVR/inst-sbc.s
+++ b/test/MC/AVR/inst-sbc.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  sbc r30, 13
-  sbc r9,  r0
-  sbc r15, r4
-  sbc r31, r31
+  sbc r0,  r15
+  sbc r15, r0 
+  sbc r16, r31
+  sbc r31, r16
 
-; CHECK: sbc r30, 13                 ; encoding: [0xed,0x09]
-; CHECK: sbc r9,  r0                 ; encoding: [0x90,0x08]
-; CHECK: sbc r15, r4                 ; encoding: [0xf4,0x08]
-; CHECK: sbc r31, r31                ; encoding: [0xff,0x0b]
+; CHECK: sbc r0,  r15               ; encoding: [0x0f,0x08]
+; CHECK: sbc r15, r0                ; encoding: [0xf0,0x08]
+; CHECK: sbc r16, r31               ; encoding: [0x0f,0x0b]
+; CHECK: sbc r31, r16               ; encoding: [0xf0,0x0b]
+

--- a/test/MC/AVR/inst-sub.s
+++ b/test/MC/AVR/inst-sub.s
@@ -3,12 +3,13 @@
 
 foo:
 
-  sub r13, r2
-  sub r9,  r3
-  sub r18, r9
-  sub r29, r29
+  sub r0,  r15
+  sub r15, r0 
+  sub r16, r31
+  sub r31, r16
 
-; CHECK: sub r13, r2                  ; encoding: [0xd2,0x18]
-; CHECK: sub r9,  r3                  ; encoding: [0x93,0x18]
-; CHECK: sub r18, 9                   ; encoding: [0x29,0x19]
-; CHECK: sub r29, r29                 ; encoding: [0xdd,0x1b]
+; CHECK: sub r0,  r15               ; encoding: [0x0f,0x18]
+; CHECK: sub r15, r0                ; encoding: [0xf0,0x18]
+; CHECK: sub r16, r31               ; encoding: [0x0f,0x1b]
+; CHECK: sub r31, r16               ; encoding: [0xf0,0x1b]
+


### PR DESCRIPTION
All of these have been tested against the instructions except for MUL since it wasn't enabled. It was triple checked for correctness, but it could use another peek.