### PR TITLE
[AVR] Fix function call for 8-bit division.

### DIFF
--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -129,6 +129,9 @@ AVRTargetLowering::AVRTargetLowering(AVRTargetMachine &tm) :
   setOperationAction(ISD::MULHS, MVT::i8, Expand);
   setOperationAction(ISD::MULHS, MVT::i16, Expand);
 
+  // Custom names for libgcc/compiler_rt functions
+  setLibcallName(RTLIB::UDIV_I8,  "__divmodhi4");
+
   setMinFunctionAlignment(1);
 }
 


### PR DESCRIPTION
This patch fixes the case described in bug #70. If any other functions have a similar issue, setLibCallName can also be used to substitute these for the correct versions.