### PR TITLE
Update CMake to 2.8.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ compiler:
 
 # Attempt to get the right GCC/Clang versions
 before_script:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo add-apt-repository ppa:kalakris/cmake -y
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository -y ppa:kubuntu-ppa/backports
   - sudo apt-get update -qq
   - sudo apt-get install cmake
   - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi


### PR DESCRIPTION
Fix build system. Can't use CMake 3 yet as there aren't prebuilt packages for 12.04. When Travis is on 14.04 and the build system breaks again, I'll upgrade it.