### PR TITLE
Treat warnings as errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_script:
   - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
   - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - export CXXFLAGS="$CXXFLAGS -Werror"
 
 script:
   - mkdir build && cd build


### PR DESCRIPTION
Since I was in the Travis build config anyway, decided to put it in place.

Tested with working CMake from other MR.