### PR TITLE
Refactor asm parser even more

### DIFF
--- a/lib/Target/AVR/AsmParser/AVRAsmParser.cpp
+++ b/lib/Target/AVR/AsmParser/AVRAsmParser.cpp
@@ -55,38 +55,21 @@ class AVRAsmParser : public MCTargetAsmParser {
   
   bool ParseDirective(AsmToken directiveID) override { return true; }
 
-  //! \brief Parses identifiers as AsmToken::Token's when needed.
-  //!
-  //! Some instructions have hard coded values as operands.
-  //! For example, the `lpm Rd, Z` instruction, where the second
-  //! operand is always explicitly Z.
-  //!
-  //! The parser naively parses `Z` and all other identifiers as immediates.
-  //! The problem with this is that the instruction matcher expects `Z` to
-  //! be of kind AsmToken::Token.
-  //!
-  //! This function fixes this by maintaining a table of operand values
-
-  //! (such as `Z`) and mnemonics (such as `lpm`) and parsing all operands
-  //! that fit the criteria as AsmToken::Token values.
-  //!
-  //! \return `false` if we found a token that fit the criteria and
-  //!         parsed it, `true` otherwise.
-  bool ParseCustomOperand(OperandVector &Operands, StringRef Mnemonic);
 
   //! \brief Parses an assembly operand.
   //! \param Operands A list to add the successfully parsed operand to.
   //! \param Mnemonic The mnemonic of the instruction.
   //! \return `false` if parsing succeeds, `true` otherwise.
-  bool ParseOperand(OperandVector &Operands, StringRef Mnemonic);
+  bool parseOperand(OperandVector &Operands, StringRef Mnemonic);
 
   //! \brief Attempts to parse a register.
   //! \return The register number, or `-1` if the token is not a register.
-  int tryParseRegister(StringRef Mnemonic);
+  int tryParseRegister();
 
   bool tryParseRegisterOperand(OperandVector &Operands,
                                StringRef Mnemonic);
 
+  //! \brief Handles target specific special cases. See definition for notes.
   unsigned validateTargetOperandClass(MCParsedAsmOperand &Op, unsigned Kind);
 
   //! \brief Given a lower (even) register returns the corresponding DREG
@@ -291,7 +274,7 @@ MatchAndEmitInstruction(SMLoc IDLoc, unsigned &Opcode,
   return true;
 }
 
-int AVRAsmParser::tryParseRegister(StringRef Mnemonic) {
+int AVRAsmParser::tryParseRegister() {
   const AsmToken &Tok = Parser.getTok();
   int RegNum = -1;
   if (Tok.is(AsmToken::Identifier)) {
@@ -313,72 +296,20 @@ bool AVRAsmParser::
   tryParseRegisterOperand(OperandVector &Operands,
                           StringRef Mnemonic){
 
-  SMLoc S = Parser.getTok().getLoc();
-  int RegNo = -1;
-
-  RegNo = tryParseRegister(Mnemonic);
-  
+  int RegNo = tryParseRegister();
   if (RegNo == -1)
     return true;
 
-  Operands.push_back(AVROperand::CreateReg(RegNo, S,
-                     Parser.getTok().getLoc()));
-  
+  AsmToken const& Tok = Parser.getTok();
+  Operands.push_back(AVROperand::CreateReg(RegNo, Tok.getLoc(), Tok.getEndLoc()));
   Parser.Lex(); // Eat register token.
+
   return false;
 }
 
-/// \brief Maps operand names to tokens.
-/// \note See ParseCustomOperand for details.
-struct CustomOperandMapping {
-  StringRef mnemonic;
-  StringRef token;
-};
-
-bool AVRAsmParser::ParseCustomOperand(OperandVector &Operands,
-                                      StringRef Mnemonic)
-{
-  // A list of (containing mnemonic, identifier) to
-  // process as tokens.
-  const CustomOperandMapping mappings[] = {
-    CustomOperandMapping { "lpm",  "Z" },
-    CustomOperandMapping { "lpmw", "Z" },
-    CustomOperandMapping { "elpm", "Z" },
-    CustomOperandMapping { "spm",  "Z" },
-
-    CustomOperandMapping { "xch", "Z" },
-    CustomOperandMapping { "las", "Z" },
-    CustomOperandMapping { "lac", "Z" },
-    CustomOperandMapping { "lat", "Z" }
-  };
-
-
-  // we only operate on identifiers
-  assert(getLexer().is(AsmToken::Identifier));
-
-  auto ident = getLexer().getTok().getIdentifier();
-
-  for(auto &mapping : mappings) {
-
-    // check if we found a match
-    if( (mapping.mnemonic.compare_lower(Mnemonic) == 0) && (mapping.token.compare_lower(ident) == 0) ) {
-      // add the token as an operand of type Token.
-      SMLoc S = Parser.getTok().getLoc();
-      Operands.push_back(AVROperand::CreateToken(mapping.token, S));
-
-      Parser.Lex();
-
-      return false;
-    }
-  }
-
-  return true;
-}
-
-
-bool AVRAsmParser::ParseOperand(OperandVector &Operands,
+bool AVRAsmParser::parseOperand(OperandVector &Operands,
                                 StringRef Mnemonic) {
-  DEBUG(dbgs() << "ParseOperand\n");
+  DEBUG(dbgs() << "parseOperand\n");
 
   SMLoc S = Parser.getTok().getLoc();
   SMLoc E = SMLoc::getFromPointer(Parser.getTok().getLoc().getPointer() - 1);
@@ -392,17 +323,6 @@ bool AVRAsmParser::ParseOperand(OperandVector &Operands,
     case AsmToken::LParen:
     case AsmToken::Integer:
     case AsmToken::String: {
-
-      // check if the operand is an identifier
-      if(getLexer().is(AsmToken::Identifier)) {
-
-        // check if we need to parse this operand as
-        // as token.
-        if(!ParseCustomOperand(Operands, Mnemonic)) {
-          return false;
-        }
-      }
-
       // try parse the operand as a register
       if(!tryParseRegisterOperand(Operands, Mnemonic)) {
         return false;
@@ -460,29 +380,23 @@ bool AVRAsmParser::ParseRegister(unsigned &RegNo, SMLoc &StartLoc,
                                   SMLoc &EndLoc) {
 
   StartLoc = Parser.getTok().getLoc();
-  RegNo = tryParseRegister("");
+  RegNo = tryParseRegister();
   EndLoc = Parser.getTok().getLoc();
   return (RegNo == (unsigned)-1);
 }
 
 bool AVRAsmParser::
-ParseInstruction(ParseInstructionInfo &Info, StringRef Name, SMLoc NameLoc,
+ParseInstruction(ParseInstructionInfo &Info, StringRef Mnemonic, SMLoc NameLoc,
                  OperandVector &Operands) {
 
-  // Create the leading tokens for the mnemonic, split by '.' characters.
-  size_t Start = 0, Next = Name.find('.');
-  StringRef Mnemonic = Name.slice(Start, Next);
-
   Operands.push_back(AVROperand::CreateToken(Mnemonic, NameLoc));
-
-  // Read the remaining operands.
   bool first = true;
   while (getLexer().isNot(AsmToken::EndOfStatement)) {
     if(!first && getLexer().is(AsmToken::Comma))
       Parser.Lex();  // Eat the comma.
 
     // Parse and remember the operand.
-    if (ParseOperand(Operands, Name)) {
+    if (parseOperand(Operands, Mnemonic)) {
       SMLoc Loc = getLexer().getLoc();
       Parser.eatToEndOfStatement();
       return Error(Loc, "unexpected token in argument list");
@@ -505,10 +419,23 @@ extern "C" void LLVMInitializeAVRAsmParser() {
 unsigned
 AVRAsmParser::validateTargetOperandClass(MCParsedAsmOperand &AsmOp, unsigned ExpectedKind) {
   AVROperand & Op = static_cast<AVROperand&>(AsmOp);
-  if (Op.isReg() && isSubclass(MatchClassKind(ExpectedKind), MCK_DREGS)) {
-    unsigned correspondingDREG = toDREG(Op.getReg());
-    if (correspondingDREG) {
-      Op.Reg.RegNum = correspondingDREG;
+  if (Op.isReg()) {
+    MatchClassKind Expected(static_cast<MatchClassKind>(ExpectedKind));
+
+    // If the instructions uses a register pair but we got a single, lower
+    // register we perform a "class cast".
+    if (isSubclass(Expected, MCK_DREGS)) {
+      unsigned correspondingDREG = toDREG(Op.getReg());
+      if (correspondingDREG) {
+        Op.Reg.RegNum = correspondingDREG;
+        return Match_Success;
+      }
+    }
+
+    // Some instructions have hard coded values as operands.
+    // For example, the `lpm Rd, Z` instruction, where the second
+    // operand is always explicitly Z.
+    if (isSubclass(Expected, MCK_Z) && Op.getReg() == AVR::R31R30) {
       return Match_Success;
     }
   }

--- a/test/MC/AVR/inst-ldd.s
+++ b/test/MC/AVR/inst-ldd.s
@@ -10,8 +10,8 @@ foo:
   ldd r9, Z+12 
   ldd r7, Z+30
 
-; CHECK: ldd r2, Y+2                  ; encoding: [0x2a.0x80]
-; CHECK: ldd r0, Y+0                  ; encoding: [0x08,0x80]
+; CHECK: ldd r2, y+2                  ; encoding: [0x2a.0x80]
+; CHECK: ldd r0, y+0                  ; encoding: [0x08,0x80]
                      
-; CHECK: ldd r9, Z+12                 ; encoding: [0x94,0x84]
-; CHECK: ldd r7, Z+30                 ; encoding: [0x76,0x8c]
+; CHECK: ldd r9, z+12                 ; encoding: [0x94,0x84]
+; CHECK: ldd r7, z+30                 ; encoding: [0x76,0x8c]

--- a/test/MC/AVR/inst-std.s
+++ b/test/MC/AVR/inst-std.s
@@ -10,8 +10,8 @@ foo:
   std Z+12, r9
   std Z+30, r7
 
-; CHECK: std Y+2,  r2                 ; encoding: [0x2a,0x82]
-; CHECK: std Y+0,  r0                 ; encoding: [0x08,0x82]
+; CHECK: std y+2,  r2                 ; encoding: [0x2a,0x82]
+; CHECK: std y+0,  r0                 ; encoding: [0x08,0x82]
 
-; CHECK: std Z+12, r9                 ; encoding: [0x94,0x86]
-; CHECK: std Z+30, r7                 ; encoding: [0x76,0x8e]
+; CHECK: std z+12, r9                 ; encoding: [0x94,0x86]
+; CHECK: std z+30, r7                 ; encoding: [0x76,0x8e]


### PR DESCRIPTION
_Ding_. Round two.

The instruction encoding for `ldd r2, Y+2` et al is still wonky. But parsing and matching works...

