### PR TITLE
Work on relocations

### DIFF
--- a/lib/Target/AVR/AVRAsmPrinter.cpp
+++ b/lib/Target/AVR/AVRAsmPrinter.cpp
@@ -43,10 +43,7 @@ public:
   explicit AVRAsmPrinter(TargetMachine &TM, std::unique_ptr<MCStreamer> Streamer) :
     AsmPrinter(TM, std::move(Streamer)) {}
 
-  const char *getPassName() const override
-  {
-    return "AVR Assembly Printer";
-  }
+  const char *getPassName() const override { return "AVR Assembly Printer"; }
 
   void printOperand(const MachineInstr *MI, unsigned OpNo, raw_ostream &O,
                     const char *Modifier = 0);

--- a/lib/Target/AVR/MCTargetDesc/AVRELFObjectWriter.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRELFObjectWriter.cpp
@@ -38,7 +38,7 @@ namespace {
 
 AVRELFObjectWriter::AVRELFObjectWriter(uint8_t OSABI)
   : MCELFObjectTargetWriter(false, OSABI, ELF::EM_AVR,
-                            /*HasRelocationAddend*/ false,
+                            true,
                             false) {}
 
 AVRELFObjectWriter::~AVRELFObjectWriter() {}
@@ -91,7 +91,7 @@ unsigned AVRELFObjectWriter::GetRelocType(const MCValue &Target,
 bool
 AVRELFObjectWriter::needsRelocateWithSymbol(const MCSymbol &Sym,
                                             unsigned Type) const {
-  return true;
+  return false;
 }
 
 MCObjectWriter *llvm::createAVRELFObjectWriter(raw_pwrite_stream &OS,

--- a/lib/Target/AVR/MCTargetDesc/AVRMCExpr.h
+++ b/lib/Target/AVR/MCTargetDesc/AVRMCExpr.h
@@ -46,12 +46,10 @@ public: // MCTargetExpr
   
   void visitUsedExpr(MCStreamer& streamer) const override;
   
-  MCSection *findAssociatedSection() const override
-  {
+  MCSection *findAssociatedSection() const override {
     return getSubExpr()->findAssociatedSection();
   }
 
-  // There are no TLS AVRMCExprs at the moment.
   void fixELFSymbolsInTLSFixups(MCAssembler &Asm) const {}
 
   bool evaluateAsConstant(int64_t & Result) const;

--- a/test/MC/AVR/oper-hilo8.s
+++ b/test/MC/AVR/oper-hilo8.s
@@ -8,6 +8,9 @@ foo:
     ldi r24, lo8(0x23)
     ldi r24, hi8(0x2342)
 
+    ldi r24, lo8(foo)
+    ldi r24, hi8(foo)
+
 ; CHECK: ldi	r24, lo8(66)            ; encoding: [0x82,0xe4]
 ; CHECK: ldi	r24, lo8(9026)          ; encoding: [0x82,0xe4]
 


### PR DESCRIPTION
Not so much a refactoring. It's more about finding the loose ends. I [enabled the relocation addend](https://github.com/avr-llvm/llvm/compare/avr-llvm:avr-support...agnat:feature/refactor_relocation_handling?expand=1#diff-a99a83bc01cc4a2046b1f1407492a553R41) and added code to handle [symbolic expressions](https://github.com/avr-llvm/llvm/compare/avr-llvm:avr-support...agnat:feature/refactor_relocation_handling?expand=1#diff-812a909bfbe7dd2e5ddb6120cec877d8R76).

#### foo.s
````
foo: ldi r24, lo8(foo)
bar: ldi r24, hi8(bar)
````

````
$ llvm-mc -triple avr-none -filetype=obj foo.s -o foo_llvm.o
$ avr-as -mmcu=atmega32 foo.s -o foo_gas.o
````
#### objdump
````
$ avr-objdump -r foo_gas.o foo_llvm.o

foo_gas.o:     file format elf32-avr

RELOCATION RECORDS FOR [.text]:
OFFSET   TYPE              VALUE 
00000000 R_AVR_LO8_LDI     .text
00000002 R_AVR_HI8_LDI     .text+0x00000002



foo_llvm.o:     file format elf32-avr

RELOCATION RECORDS FOR [.text]:
OFFSET   TYPE              VALUE 
00000000 R_AVR_LO8_LDI     .text
00000002 R_AVR_HI8_LDI     .text+0x00000002
````

Looking good.