### PR TITLE
Print pointer register names only when they are requested

### DIFF
--- a/lib/Target/AVR/AVRRegisterInfo.td
+++ b/lib/Target/AVR/AVRRegisterInfo.td
@@ -12,7 +12,10 @@
 //===----------------------------------------------------------------------===//
 
 // general purpose register definition
-class AVRReg<bits<16> num, string n, list<Register> subregs = []>
+class AVRReg<bits<16> num,
+             string n,
+             list<Register> subregs = [],
+             list<string> altNames = []>
   : RegisterWithSubRegs<n, subregs>
 {
   field bits<16> Num = num;
@@ -20,6 +23,7 @@ class AVRReg<bits<16> num, string n, list<Register> subregs = []>
   let HWEncoding = num;
   let Namespace = "AVR";
   let SubRegs = subregs;
+  let AltNames = altNames;
 }
 
 // subregister indices
@@ -28,6 +32,11 @@ let Namespace = "AVR" in
   def sub_lo : SubRegIndex<8>;
   def sub_hi : SubRegIndex<8, 8>;
 }
+
+let Namespace = "AVR" in {
+  def ptr : RegAltNameIndex;
+}
+
 
 //===----------------------------------------------------------------------===//
 //  Register definitions
@@ -74,9 +83,15 @@ CoveredBySubRegs = 1 in
 {
   // 16 bit register pairs
   def SP     : AVRReg<32, "SP",      [SPL, SPH]>, DwarfRegNum<[32]>;
-  def R31R30 : AVRReg<30, "Z",       [R30, R31]>, DwarfRegNum<[30]>;
-  def R29R28 : AVRReg<28, "Y",       [R28, R29]>, DwarfRegNum<[28]>;
-  def R27R26 : AVRReg<26, "X",       [R26, R27]>, DwarfRegNum<[26]>;
+
+  // The pointer registers (X,Y,Z) are a special case because they
+  // are printed as a `high:low` pair when a DREG is expected,
+  // but printed using `X`, `Y`, `Z` when a pointer register is expected.
+  let RegAltNameIndices = [ptr] in {
+      def R31R30 : AVRReg<30, "r31:r30", [R30, R31], ["Z"]>, DwarfRegNum<[30]>;
+      def R29R28 : AVRReg<28, "r29:r28", [R28, R29], ["Y"]>, DwarfRegNum<[28]>;
+      def R27R26 : AVRReg<26, "r27:r26", [R26, R27], ["X"]>, DwarfRegNum<[26]>;
+  }
   def R25R24 : AVRReg<24, "r25:r24", [R24, R25]>, DwarfRegNum<[24]>;
   def R23R22 : AVRReg<22, "r23:r22", [R22, R23]>, DwarfRegNum<[22]>;
   def R21R20 : AVRReg<20, "r21:r20", [R20, R21]>, DwarfRegNum<[20]>;
@@ -174,14 +189,14 @@ def PTRREGS : RegisterClass<"AVR", [i16], 8,
     add R27R26, // X
         R29R28, // Y
         R31R30  // Z
-  )>;
+  ), ptr>;
 
 // 16 bit register class for the ldd and std instructions
 // aka y, z
 def PTRDISPREGS : RegisterClass<"AVR", [i16], 8,
   (
     add R31R30, R29R28
-  )>;
+  ), ptr>;
 
 // We have a bunch of instructions with an explicit Z register argument. We
 // model this using a register class containing only the Z register.

--- a/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
+++ b/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
@@ -79,23 +79,15 @@ void AVRInstPrinter::printInst(const MCInst *MI, raw_ostream &O,
 
 const char *
 AVRInstPrinter::getPrettyRegisterName(unsigned RegNum, MCRegisterInfo const& MRI) {
-  unsigned RegToPrint = RegNum;
 
 #ifdef LLVM_AVR_GCC_COMPAT
   // GCC prints register pairs by just printing the lower register
   // If the register contains a subregister, print it instead
-  if (MRI.getSubReg(RegNum, 1) != 0)
-  {
-    auto RegLoNum = MRI.getSubReg(RegNum, AVR::sub_lo);
-
-    if(RegLoNum == AVR::NoRegister)
-      RegToPrint = RegNum; // print the entire register pair
-    else
-      RegToPrint = RegLoNum; // print the lower register
-  }
+  auto RegLoNum = MRI.getSubReg(RegNum, AVR::sub_lo);
+  RegNum = (RegLoNum != AVR::NoRegister) ? RegLoNum : RegNum;
 #endif
 
-  return getRegisterName(RegToPrint);
+  return getRegisterName(RegNum);
 }
 
 

--- a/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
+++ b/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
@@ -94,7 +94,13 @@ void AVRInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
   const MCOperand &Op = MI->getOperand(OpNo);
 
   if (Op.isReg()) {
-    O << getPrettyRegisterName(Op.getReg(), MRI);
+    bool isDREGS = false;
+
+    if(isDREGS) {
+
+    } else {
+        O << getPrettyRegisterName(Op.getReg(), MRI);
+    }
   } else if (Op.isImm()) {
     O << Op.getImm();
   } else {

--- a/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
+++ b/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
@@ -78,15 +78,24 @@ void AVRInstPrinter::printInst(const MCInst *MI, raw_ostream &O,
 }
 
 const char *
-AVRInstPrinter::getPrettyRegisterName(unsigned RegNo, MCRegisterInfo const& MRI) {
+AVRInstPrinter::getPrettyRegisterName(unsigned RegNum, MCRegisterInfo const& MRI) {
+  unsigned RegToPrint = RegNum;
+
 #ifdef LLVM_AVR_GCC_COMPAT
-  if (AVRMCRegisterClasses[AVR::DREGSRegClassID].contains(RegNo) &&
-      !AVRMCRegisterClasses[AVR::PTRREGSRegClassID].contains(RegNo))
+  // GCC prints register pairs by just printing the lower register
+  // If the register contains a subregister, print it instead
+  if (MRI.getSubReg(RegNum, 1) != 0)
   {
-    return getRegisterName(MRI.getSubReg(RegNo, AVR::sub_lo));
+    auto RegLoNum = MRI.getSubReg(RegNum, AVR::sub_lo);
+
+    if(RegLoNum == AVR::NoRegister)
+      RegToPrint = RegNum; // print the entire register pair
+    else
+      RegToPrint = RegLoNum; // print the lower register
   }
 #endif
-  return getRegisterName(RegNo);
+
+  return getRegisterName(RegToPrint);
 }
 
 

--- a/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
+++ b/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
@@ -18,6 +18,8 @@
 
 #include "llvm/MC/MCExpr.h"
 #include "llvm/MC/MCInst.h"
+#include "llvm/MC/MCInstrDesc.h"
+#include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormattedStream.h"
@@ -92,14 +94,19 @@ void AVRInstPrinter::printOperand(const MCInst *MI, unsigned OpNo,
                                   raw_ostream &O)
 {
   const MCOperand &Op = MI->getOperand(OpNo);
+  const MCOperandInfo& MOI = this->MII.get(MI->getOpcode()).OpInfo[OpNo];
+
 
   if (Op.isReg()) {
-    bool isDREGS = false;
+    //.RegClass == AVR::GPR8RegClassID
+    bool isPtrReg = (MOI.RegClass == AVR::PTRREGSRegClassID) ||
+                    (MOI.RegClass == AVR::PTRDISPREGSRegClassID) ||
+                    (MOI.RegClass == AVR::ZREGSRegClassID);
 
-    if(isDREGS) {
-
+    if(isPtrReg) {
+      O << getRegisterName(Op.getReg(), AVR::ptr);
     } else {
-        O << getPrettyRegisterName(Op.getReg(), MRI);
+      O << getPrettyRegisterName(Op.getReg(), MRI);
     }
   } else if (Op.isImm()) {
     O << Op.getImm();

--- a/lib/Target/AVR/InstPrinter/AVRInstPrinter.h
+++ b/lib/Target/AVR/InstPrinter/AVRInstPrinter.h
@@ -18,6 +18,8 @@
 
 # include "llvm/MC/MCInstPrinter.h"
 
+# include "MCTargetDesc/AVRMCTargetDesc.h"
+
 namespace llvm {
 /*!
  * Prints AVR instructions to a textual stream.
@@ -38,7 +40,9 @@ public: // MCInstPrinter
                  const MCSubtargetInfo &STI) override;
 
 private:
-  static const char *getRegisterName(unsigned RegNo);
+  static const char *getRegisterName(unsigned RegNo,
+                                     unsigned AltIdx = AVR::NoRegAltName);
+
   void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O);
   void print_pcrel_imm(const MCInst *MI, unsigned OpNo, raw_ostream &O);
 

--- a/test/CodeGen/AVR/call.ll
+++ b/test/CodeGen/AVR/call.ll
@@ -141,7 +141,7 @@ define void @testcallprologue() {
 ; CHECK-LABEL: testcallprologue:
 ; CHECK: push r28
 ; CHECK: push r29
-; CHECK: sbiw Y, 27
+; CHECK: sbiw r28, 27
 ; CHECK: ldi [[REG1:r[0-9]+]], 88
 ; CHECK: std Y+9, [[REG1]]
 ; CHECK: ldi [[REG1:r[0-9]+]], 11
@@ -175,7 +175,7 @@ define i32 @icall(i32 (i32)* %foo) {
 ; CHECK: ldi r23, 248
 ; CHECK: ldi r24, 214
 ; CHECK: ldi r25, 198
-; CHECK: movw Z, [[REG]]
+; CHECK: movw r30, [[REG]]
 ; CHECK: icall
 ; CHECK: subi r22, 251
 ; CHECK: sbci r23, 255

--- a/test/CodeGen/AVR/frame.ll
+++ b/test/CodeGen/AVR/frame.ll
@@ -13,14 +13,14 @@ entry:
 ; CHECK: push r29
 ; CHECK: in r28, 61
 ; CHECK-NEXT: in r29, 62
-; CHECK-NEXT: sbiw Y, [[SIZE:[0-9]+]]
+; CHECK-NEXT: sbiw r28, [[SIZE:[0-9]+]]
 ; CHECK-NEXT: in r0, 63
 ; CHECK-NEXT: cli
 ; CHECK-NEXT: out 62, r29
 ; CHECK-NEXT: out 63, r0
 ; CHECK-NEXT: out 61, r28
 ; epilogue code:
-; CHECK: adiw Y, [[SIZE]]
+; CHECK: adiw r28, [[SIZE]]
 ; CHECK-NEXT: in r0, 63
 ; CHECK-NEXT: cli
 ; CHECK-NEXT: out 62, r29

--- a/test/MC/AVR/inst-adiw.s
+++ b/test/MC/AVR/inst-adiw.s
@@ -3,20 +3,20 @@
 
 foo:
 
-  adiw X,  12
-  adiw X,  63
+  adiw r26,  12
+  adiw r26,  63
   
-  adiw Y,  17
-  adiw Y,  0
+  adiw r28,  17
+  adiw r28,  0
   
-  adiw Z,  63
-  adiw Z,  3
+  adiw r30,  63
+  adiw r30,  3
 
-; CHECK: adiw X,  12                 ; encoding: [0x1c,0x96]
-; CHECK: adiw X,  63                 ; encoding: [0xdf,0x96]
+; CHECK: adiw r26,  12               ; encoding: [0x1c,0x96]
+; CHECK: adiw r26,   63               ; encoding: [0xdf,0x96]
 
-; CHECK: adiw Y,  17                 ; encoding: [0x61,0x96]
-; CHECK: adiw Y,  0                  ; encoding: [0x20,0x96]
+; CHECK: adiw r28,  17               ; encoding: [0x61,0x96]
+; CHECK: adiw r28,  0                ; encoding: [0x20,0x96]
 
-; CHECK: adiw Z,  63                 ; encoding: [0xff,0x96]
-; CHECK: adiw Z,  3                  ; encoding: [0x33,0x96]
+; CHECK: adiw r30,  63               ; encoding: [0xff,0x96]
+; CHECK: adiw r30,  3                ; encoding: [0x33,0x96]

--- a/test/MC/AVR/inst-sbiw.s
+++ b/test/MC/AVR/inst-sbiw.s
@@ -3,29 +3,29 @@
 
 foo:
 
-  sbiw X,  54
-  sbiw X,  63
+  sbiw r26, 54
+  sbiw X,   63
   
-  sbiw Y,  52
-  sbiw Y,  0
+  sbiw 28,  52
+  sbiw r28, 0
   
-  sbiw Z,  63
-  sbiw Z,  47
+  sbiw r30, 63
+  sbiw Z,   47
 
   sbiw r24,     1
   sbiw r25:r24, 2
   sbiw r27:r26, 3
 
 
-; CHECK: sbiw X,  54                 ; encoding: [0xd6,0x97]
-; CHECK: sbiw X,  63                 ; encoding: [0xdf,0x97]
+; CHECK: sbiw r26,  54                 ; encoding: [0xd6,0x97]
+; CHECK: sbiw r26,  63                 ; encoding: [0xdf,0x97]
 
-; CHECK: sbiw Y,  52                 ; encoding: [0xe4,0x97]
-; CHECK: sbiw Y,  0                  ; encoding: [0x20,0x97]
+; CHECK: sbiw r28,  52                 ; encoding: [0xe4,0x97]
+; CHECK: sbiw r28,  0                  ; encoding: [0x20,0x97]
 
-; CHECK: sbiw Z,  63                 ; encoding: [0xff,0x97]
-; CHECK: sbiw Z,  47                 ; encoding: [0xbf,0x97]
+; CHECK: sbiw r30,  63                 ; encoding: [0xff,0x97]
+; CHECK: sbiw r30,  47                 ; encoding: [0xbf,0x97]
 
-; CHECK: sbiw r24,  1                ; encoding: [0x01,0x97]
-; CHECK: sbiw r24,  2                ; encoding: [0x02,0x97]
-; CHECK: sbiw X,    3                ; encoding: [0x13,0x97]
+; CHECK: sbiw r24,  1                  ; encoding: [0x01,0x97]
+; CHECK: sbiw r24,  2                  ; encoding: [0x02,0x97]
+; CHECK: sbiw r26,  3                  ; encoding: [0x13,0x97]

--- a/utils/TableGen/AsmMatcherEmitter.cpp
+++ b/utils/TableGen/AsmMatcherEmitter.cpp
@@ -2187,6 +2187,13 @@ static void emitMatchRegisterName(CodeGenTarget &Target, Record *AsmParser,
 
     Matches.emplace_back(Reg.TheDef->getValueAsString("AsmName"),
                          "return " + utostr(Reg.EnumValue) + ";");
+
+    auto AltNames = Reg.TheDef->getValueAsListOfStrings("AltNames");
+
+    for(auto AltName : AltNames) {
+        Matches.emplace_back(AltName,
+                             "return " + utostr(Reg.EnumValue) + ";");
+    }
   }
 
   OS << "static unsigned MatchRegisterName(StringRef Name) {\n";


### PR DESCRIPTION
This PR changes `AVRRegisterInfo.td` to treat `X`, `Y`, and `Z` as aliases of `r27:r26`, `r29:r28`, and `r31:r30` respectively.

It modifies TableGen to match based on register aliases as well as their names in `AVRAsmParser::MatchRegisterName`.

It also modifies the instruction printer to only print the `X`, `Y`, and `Z` aliases if the instruction has operands of type `PTRREGS`, `PTRDISPREGS`, or `ZREGS`. This causes `movw r30, r28` to be printed unchanged - `movw r30, r28`, instead of `movw Z, Y`.

@agnat Could you look over this?