### PR TITLE
Experimental: Better inline asm

### DIFF
--- a/lib/Target/AVR/AVRAsmPrinter.cpp
+++ b/lib/Target/AVR/AVRAsmPrinter.cpp
@@ -110,9 +110,9 @@ bool AVRAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNum,
                               "using 'A'..'Z' operand extracodes.");
       unsigned Reg = RegOp.getReg();
 
-      unsigned ByteNumber = ExtraCode[0] -'A';
+      unsigned ByteNumber = ExtraCode[0] - 'A';
 
-      unsigned OpFlags = MI->getOperand(OpNum-1).getImm();
+      unsigned OpFlags = MI->getOperand(OpNum - 1).getImm();
       unsigned NumOpRegs = InlineAsm::getNumOperandRegisters(OpFlags);
 
       const TargetRegisterInfo *TRI = MF->getSubtarget().getRegisterInfo();

--- a/lib/Target/AVR/AVRAsmPrinter.cpp
+++ b/lib/Target/AVR/AVRAsmPrinter.cpp
@@ -102,34 +102,32 @@ bool AVRAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNum,
   {
     if (ExtraCode[1] != 0) return true; // Unknown modifier.
 
-    if  (ExtraCode[0] >= 'A' && ExtraCode[0] <= 'Z')
-    {
+    if  (ExtraCode[0] >= 'A' && ExtraCode[0] <= 'Z') {
       const MachineOperand& RegOp = MI->getOperand(OpNum);
 
       assert(RegOp.isReg() && "Operand must be a register when you're"
                               "using 'A'..'Z' operand extracodes.");
       unsigned Reg = RegOp.getReg();
 
-      unsigned ByteNumber = ExtraCode[0] - 'A';
-
-      unsigned OpFlags = MI->getOperand(OpNum - 1).getImm();
-      unsigned NumOpRegs = InlineAsm::getNumOperandRegisters(OpFlags);
 
       const TargetRegisterInfo *TRI = MF->getSubtarget().getRegisterInfo();
 
       unsigned BytesPerReg = TRI->getMinimalPhysRegClass(Reg)->getSize();
+      unsigned ByteIndex = ExtraCode[0] - 'A';
 
-      assert(BytesPerReg <= 2 && "Only 8 and 16 bit regs are supported.");
-
-      unsigned RegIdx = ByteNumber / BytesPerReg;
-      assert(RegIdx < NumOpRegs && "Multibyte index out of range.");
-
-      Reg = MI->getOperand(OpNum + RegIdx).getReg();
-
-      if (BytesPerReg == 2)
-      {
-        Reg = TRI->getSubReg(Reg, ByteNumber % BytesPerReg ?
-                                  AVR::sub_hi : AVR::sub_lo);
+      int SubRegisterIndex = AVR::NoSubRegister;
+      if (BytesPerReg == 2) {
+        SubRegisterIndex = ByteIndex % BytesPerReg ? AVR::sub_hi : AVR::sub_lo;
+      } else if (BytesPerReg == 4){
+        switch (ByteIndex % BytesPerReg) {
+          case 0: SubRegisterIndex = AVR::qsub_0; break;
+          case 1: SubRegisterIndex = AVR::qsub_1; break;
+          case 2: SubRegisterIndex = AVR::qsub_2; break;
+          case 3: SubRegisterIndex = AVR::qsub_3; break;
+        }
+      }
+      if (SubRegisterIndex != AVR::NoSubRegister) {
+        Reg = TRI->getSubReg(Reg, SubRegisterIndex);
       }
 
       O << AVRInstPrinter::getPrettyRegisterName(Reg, MRI);

--- a/lib/Target/AVR/AVRISelDAGToDAG.cpp
+++ b/lib/Target/AVR/AVRISelDAGToDAG.cpp
@@ -41,12 +41,6 @@ public:
 
   bool runOnMachineFunction(MachineFunction &MF) override;
 
-  // Address Selection.
-  bool SelectAddr(SDNode *Op, SDValue N, SDValue &Base, SDValue &Disp);
-  // Indexed load (postinc and predec) matching code.
-  SDNode *SelectIndexedLoad(SDNode *N);
-  // Indexed progmem load (only postinc) matching code.
-  unsigned SelectIndexedProgMemLoad(const LoadSDNode *LD, MVT VT);
 
   bool SelectInlineAsmMemoryOperand(const SDValue &Op, unsigned ConstraintCode,
                                     std::vector<SDValue> &OutOps) override;
@@ -55,6 +49,16 @@ public:
   #include "AVRGenDAGISel.inc"
 
 private:
+
+  SDNode * selectInlineAsm(SDNode* N);
+  SDNode * createGPR8QuadNode(EVT VT, SDValue V0, SDValue V1, SDValue V2, SDValue V3);
+  // Address Selection.
+  bool selectAddr(SDNode *Op, SDValue N, SDValue &Base, SDValue &Disp);
+  // Indexed load (postinc and predec) matching code.
+  SDNode *selectIndexedLoad(SDNode *N);
+  // Indexed progmem load (only postinc) matching code.
+  unsigned selectIndexedProgMemLoad(const LoadSDNode *LD, MVT VT);
+
   SDNode *Select(SDNode *N) override;
   
   const AVRSubtarget *Subtarget;
@@ -70,7 +74,7 @@ AVRDAGToDAGISel::runOnMachineFunction(MachineFunction &MF) {
 }
 
 bool
-AVRDAGToDAGISel::SelectAddr(SDNode *Op, SDValue N, SDValue &Base, SDValue &Disp)
+AVRDAGToDAGISel::selectAddr(SDNode *Op, SDValue N, SDValue &Base, SDValue &Disp)
 {
   SDLoc DL(Op);
 
@@ -132,7 +136,7 @@ AVRDAGToDAGISel::SelectAddr(SDNode *Op, SDValue N, SDValue &Base, SDValue &Disp)
   return false;
 }
 
-SDNode *AVRDAGToDAGISel::SelectIndexedLoad(SDNode *N)
+SDNode *AVRDAGToDAGISel::selectIndexedLoad(SDNode *N)
 {
   const LoadSDNode *LD = cast<LoadSDNode>(N);
   ISD::MemIndexedMode AM = LD->getAddressingMode();
@@ -173,7 +177,7 @@ SDNode *AVRDAGToDAGISel::SelectIndexedLoad(SDNode *N)
                                 LD->getBasePtr(), LD->getChain());
 }
 
-unsigned AVRDAGToDAGISel::SelectIndexedProgMemLoad(const LoadSDNode *LD, MVT VT)
+unsigned AVRDAGToDAGISel::selectIndexedProgMemLoad(const LoadSDNode *LD, MVT VT)
 {
   ISD::MemIndexedMode AM = LD->getAddressingMode();
 
@@ -238,7 +242,7 @@ bool AVRDAGToDAGISel::SelectInlineAsmMemoryOperand(const SDValue &Op,
   if (Op->getOpcode() == ISD::FrameIndex)
   {
     SDValue Base, Disp;
-    if (SelectAddr(Op.getNode(), Op, Base, Disp))
+    if (selectAddr(Op.getNode(), Op, Base, Disp))
     {
       OutOps.push_back(Base);
       OutOps.push_back(Disp);
@@ -338,6 +342,169 @@ bool AVRDAGToDAGISel::SelectInlineAsmMemoryOperand(const SDValue &Op,
   return false;
 }
 
+SDNode *
+AVRDAGToDAGISel::selectInlineAsm(SDNode* N) {
+  std::vector<SDValue> AsmNodeOperands;
+  unsigned Flag, Kind;
+  bool Changed = false;
+  unsigned NumOps = N->getNumOperands();
+
+  // Normally, i64 data is bounded to two arbitrary GRPs for "%r" constraint.
+  // However, some instrstions (e.g. ldrexd/strexd in ARM mode) require
+  // (even/even+1) GPRs and use %n and %Hn to refer to the individual regs
+  // respectively. Since there is no constraint to explicitly specify a
+  // reg pair, we use GPRPair reg class for "%r" for 64-bit data. For Thumb,
+  // the 64-bit data may be referred by H, Q, R modifiers, so we still pack
+  // them into a GPRPair.
+
+  SDLoc dl(N);
+  SDValue Glue = N->getGluedNode() ? N->getOperand(NumOps-1) : SDValue(nullptr,0);
+
+  SmallVector<bool, 8> OpChanged;
+  // Glue node will be appended late.
+  for(unsigned i = 0, e = N->getGluedNode() ? NumOps - 1 : NumOps; i < e; ++i) {
+    SDValue op = N->getOperand(i);
+    AsmNodeOperands.push_back(op);
+
+    if (i < InlineAsm::Op_FirstOperand)
+      continue;
+
+    if (ConstantSDNode *C = dyn_cast<ConstantSDNode>(N->getOperand(i))) {
+      Flag = C->getZExtValue();
+      Kind = InlineAsm::getKind(Flag);
+    } else
+      continue;
+
+    // Immediate operands to inline asm in the SelectionDAG are modeled with
+    // two operands. The first is a constant of value InlineAsm::Kind_Imm, and
+    // the second is a constant with the value of the immediate. If we get here
+    // and we have a Kind_Imm, skip the next operand, and continue.
+    if (Kind == InlineAsm::Kind_Imm) {
+      SDValue op = N->getOperand(++i);
+      AsmNodeOperands.push_back(op);
+      continue;
+    }
+
+    unsigned NumRegs = InlineAsm::getNumOperandRegisters(Flag);
+    if (NumRegs)
+      OpChanged.push_back(false);
+
+    unsigned DefIdx = 0;
+    bool IsTiedToChangedOp = false;
+    // If it's a use that is tied with a previous def, it has no
+    // reg class constraint.
+    if (Changed && InlineAsm::isUseOperandTiedToDef(Flag, DefIdx))
+      IsTiedToChangedOp = OpChanged[DefIdx];
+
+    if (Kind != InlineAsm::Kind_RegUse && Kind != InlineAsm::Kind_RegDef
+        && Kind != InlineAsm::Kind_RegDefEarlyClobber)
+      continue;
+
+    unsigned RC;
+    bool HasRC = InlineAsm::hasRegClassConstraint(Flag, RC);
+    if ((!IsTiedToChangedOp && (!HasRC || RC != AVR::GPR8RegClassID)) // Poof
+        || NumRegs != 2)
+      continue;
+
+    assert((i+2 < NumOps) && "Invalid number of operands in inline asm");
+    SDValue V0 = N->getOperand(i+1);
+    SDValue V1 = N->getOperand(i+2);
+    unsigned Reg0 = cast<RegisterSDNode>(V0)->getReg();
+    unsigned Reg1 = cast<RegisterSDNode>(V1)->getReg();
+    SDValue PairedReg;
+    MachineRegisterInfo &MRI = MF->getRegInfo();
+
+    if (Kind == InlineAsm::Kind_RegDef ||
+        Kind == InlineAsm::Kind_RegDefEarlyClobber) {
+      // Replace the two GPRs with 1 GPRPair and copy values from GPRPair to
+      // the original GPRs.
+
+      unsigned GPVR = MRI.createVirtualRegister(&AVR::GPR8QuadRegClass);
+      PairedReg = CurDAG->getRegister(GPVR, MVT::Untyped);
+      SDValue Chain = SDValue(N,0);
+
+      SDNode *GU = N->getGluedUser();
+      SDValue RegCopy = CurDAG->getCopyFromReg(Chain, dl, GPVR, MVT::Untyped,
+                                               Chain.getValue(1));
+
+      // Extract values from a GPRPair reg and copy to the original GPR reg.
+      SDValue Sub0 = CurDAG->getTargetExtractSubreg(AVR::qsub_0, dl, MVT::i8,
+                                                    RegCopy);
+      SDValue Sub1 = CurDAG->getTargetExtractSubreg(AVR::qsub_1, dl, MVT::i8,
+                                                    RegCopy);
+      SDValue T0 = CurDAG->getCopyToReg(Sub0, dl, Reg0, Sub0,
+                                        RegCopy.getValue(1));
+      SDValue T1 = CurDAG->getCopyToReg(Sub1, dl, Reg1, Sub1, T0.getValue(1));
+
+      // Update the original glue user.
+      std::vector<SDValue> Ops(GU->op_begin(), GU->op_end()-1);
+      Ops.push_back(T1.getValue(1));
+      CurDAG->UpdateNodeOperands(GU, Ops);
+    }
+    else {
+      // For Kind  == InlineAsm::Kind_RegUse, we first copy two GPRs into a
+      // GPRPair and then pass the GPRPair to the inline asm.
+      SDValue Chain = AsmNodeOperands[InlineAsm::Op_InputChain];
+
+      // As REG_SEQ doesn't take RegisterSDNode, we copy them first.
+      SDValue T0 = CurDAG->getCopyFromReg(Chain, dl, Reg0, MVT::i8,
+                                          Chain.getValue(1));
+      SDValue T1 = CurDAG->getCopyFromReg(Chain, dl, Reg1, MVT::i8,
+                                          T0.getValue(1));
+      SDValue Quad = SDValue(createGPR8QuadNode(MVT::Untyped, T0, T1, T1, T1), 0); // XXX
+
+      // Copy REG_SEQ into a GPRPair-typed VR and replace the original two
+      // i32 VRs of inline asm with it.
+      unsigned GPVR = MRI.createVirtualRegister(&AVR::GPR8QuadRegClass);
+      PairedReg = CurDAG->getRegister(GPVR, MVT::Untyped);
+      Chain = CurDAG->getCopyToReg(T1, dl, GPVR, Quad, T1.getValue(1));
+
+      AsmNodeOperands[InlineAsm::Op_InputChain] = Chain;
+      Glue = Chain.getValue(1);
+    }
+
+    Changed = true;
+
+    if(PairedReg.getNode()) {
+      OpChanged[OpChanged.size() -1 ] = true;
+      Flag = InlineAsm::getFlagWord(Kind, 1 /* RegNum*/);
+      if (IsTiedToChangedOp)
+        Flag = InlineAsm::getFlagWordForMatchingOp(Flag, DefIdx);
+      else
+        Flag = InlineAsm::getFlagWordForRegClass(Flag, AVR::GPR8QuadRegClassID);
+      // Replace the current flag.
+      AsmNodeOperands[AsmNodeOperands.size() -1] = CurDAG->getTargetConstant(Flag, dl, MVT::i32);
+      // Add the new register node and skip the original two GPRs.
+      AsmNodeOperands.push_back(PairedReg);
+      // Skip the next two GPRs.
+      i += 4;
+    }
+  }
+  if (Glue.getNode())
+    AsmNodeOperands.push_back(Glue);
+  if (!Changed)
+    return nullptr;
+
+  SDValue New = CurDAG->getNode(ISD::INLINEASM, SDLoc(N),
+                                CurDAG->getVTList(MVT::Other, MVT::Glue), AsmNodeOperands);
+  New->setNodeId(-1);
+  return New.getNode();
+
+}
+
+SDNode *
+AVRDAGToDAGISel::createGPR8QuadNode(EVT VT, SDValue V0, SDValue V1, SDValue V2, SDValue V3) {
+  SDLoc dl(V0.getNode());
+  SDValue RegClass =
+  CurDAG->getTargetConstant(AVR::GPR8QuadRegClassID, dl, MVT::i8);
+  SDValue SubReg0 = CurDAG->getTargetConstant(AVR::qsub_0, dl, MVT::i8);
+  SDValue SubReg1 = CurDAG->getTargetConstant(AVR::qsub_1, dl, MVT::i8);
+  SDValue SubReg2 = CurDAG->getTargetConstant(AVR::qsub_2, dl, MVT::i8);
+  SDValue SubReg3 = CurDAG->getTargetConstant(AVR::qsub_3, dl, MVT::i8);
+  const SDValue Ops[] = { RegClass, V0, SubReg0, V1, SubReg1, V2, SubReg2, V3, SubReg3 };
+  return CurDAG->getMachineNode(TargetOpcode::REG_SEQUENCE, dl, VT, Ops);
+}
+
 SDNode *AVRDAGToDAGISel::Select(SDNode *N)
 {
   unsigned Opcode = N->getOpcode();
@@ -424,7 +591,7 @@ SDNode *AVRDAGToDAGISel::Select(SDNode *N)
                                      Chain.getValue(1));
 
         // Check if the opcode can be converted into an indexed load.
-        if (unsigned LPMOpc = SelectIndexedProgMemLoad(LD, VT))
+        if (unsigned LPMOpc = selectIndexedProgMemLoad(LD, VT))
         {
           // It is legal to fold the load into an indexed load.
           ResNode = CurDAG->getMachineNode(LPMOpc, DL, VT, MVT::i16, MVT::Other,
@@ -463,7 +630,7 @@ SDNode *AVRDAGToDAGISel::Select(SDNode *N)
       }
 
       // Check if the opcode can be converted into an indexed load.
-      if (SDNode *ResNode = SelectIndexedLoad(N))
+      if (SDNode *ResNode = selectIndexedLoad(N))
       {
         return ResNode;
       }
@@ -527,7 +694,9 @@ SDNode *AVRDAGToDAGISel::Select(SDNode *N)
     }
   case ISD::INLINEASM:
     {
-      // TODO
+      SDNode * ResNode = selectInlineAsm(N);
+      if (ResNode)
+        return ResNode;
       break;
     }
 

--- a/lib/Target/AVR/AVRISelDAGToDAG.cpp
+++ b/lib/Target/AVR/AVRISelDAGToDAG.cpp
@@ -216,7 +216,7 @@ bool AVRDAGToDAGISel::SelectInlineAsmMemoryOperand(const SDValue &Op,
 {
   // Yes hardcoded 'm' symbol. Just because it also has been hardcoded in
   // SelectionDAGISel (callee for this method).
-  assert(ConstraintCode == 'm' && "Unexpected asm memory constraint");
+  // assert(ConstraintCode == 'm' && "Unexpected asm memory constraint");
 
   //MachineFunction& MF = CurDAG->getMachineFunction();
   MachineRegisterInfo &RI = MF->getRegInfo();
@@ -525,6 +525,12 @@ SDNode *AVRDAGToDAGISel::Select(SDNode *N)
 
       return ResNode;
     }
+  case ISD::INLINEASM:
+    {
+      // TODO
+      break;
+    }
+
   }
 
   SDNode *ResNode = SelectCode(N);

--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -1669,7 +1669,7 @@ AVRTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
   // We only support i8 and i16.
   //
   //:FIXME: remove this assert for now since it gets sometimes executed
-  //assert((VT == MVT::i16 || VT == MVT::i8) && "Wrong operand type.");
+  assert((VT == MVT::i16 || VT == MVT::i8) && "Wrong operand type.");
 
   if (Constraint.size() == 1)
   {

--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -1675,6 +1675,7 @@ void AVRTargetLowering::LowerAsmOperandForConstraint(SDValue Op,
   CONSTRAINT_VALUE(P);
   CONSTRAINT_VALUE(R);
 
+  CONSTRAINT_VALUE(G);
 #undef CONSTRAINT_VALUE
 
   }

--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -1504,7 +1504,7 @@ AVRTargetLowering::getConstraintType(const std::string &Constraint) const
     case 'N': // Integer constant (Range: -1)
     case 'O': // Integer constant (Range: 8, 16, 24)
     case 'P': // Integer constant (Range: 1)
-    case 'R': // Integer constant (Range: -6 to 5)x
+    case 'R': // Integer constant (Range: -6 to 5)
       return C_Other;
     default:
       break;
@@ -1591,18 +1591,14 @@ AVRTargetLowering::getSingleConstraintMatchWeight(AsmOperandInfo &info,
   return CW_Invalid;
 }
 
+
+
 std::pair<unsigned, const TargetRegisterClass *>
 AVRTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
                                                 const std::string &Constraint,
                                                 MVT VT) const
 {
   auto STI = static_cast<const AVRTargetMachine&>(this->getTargetMachine()).getSubtargetImpl();
-
-  // We only support i8 and i16.
-  //
-  //:FIXME: remove this assert for now since it gets sometimes executed
-  assert((VT == MVT::i16 || VT == MVT::i8) && "Wrong operand type.");
-
   if (Constraint.size() == 1)
   {
     switch (Constraint[0])
@@ -1620,7 +1616,7 @@ AVRTargetLowering::getRegForInlineAsmConstraint(const TargetRegisterInfo *TRI,
     case 'q': // Stack pointer register: SPH:SPL.
       return std::make_pair(0U, &AVR::GPRSPRegClass);
     case 'r': // Any register: r0..r31.
-      return std::make_pair(0U, VT == MVT::i8 ? &AVR::GPR8RegClass : &AVR::DREGSRegClass);
+        return std::make_pair(0U, VT == MVT::i16 ? &AVR::DREGSRegClass : &AVR::GPR8RegClass);
     case 't': // Temporary register: r0.
       return std::make_pair(unsigned(AVR::R0), &AVR::GPR8RegClass);
     case 'w': // Special upper register pairs: r24, r26, r28, r30.

--- a/lib/Target/AVR/AVRInlineAsmConstraints.h
+++ b/lib/Target/AVR/AVRInlineAsmConstraints.h
@@ -1,0 +1,123 @@
+//===-- AVRConstraints - Inline Assembly Constraints ------------*- C++ -*-===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+// This file is distributed under the University of Illinois Open Source
+// License. See LICENSE.TXT for details.
+//
+//===----------------------------------------------------------------------===//
+//
+//
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_AVR_INLINE_ASM_CONSTRAINTS_H
+# define LLVM_AVR_INLINE_ASM_CONSTRAINTS_H
+
+# include "llvm/CodeGen/SelectionDAG.h"
+
+namespace llvm { namespace AVR { namespace Constraints {
+
+struct Integer {};
+struct Float   {};
+
+template <typename T> struct SelectConstantType;
+template <> struct SelectConstantType<Integer> { typedef ConstantInt Type; };
+template <> struct SelectConstantType<Float>   { typedef ConstantFP Type; };
+
+template <typename T> struct SelectNodeType;
+template <> struct SelectNodeType<Integer> { typedef ConstantSDNode Type; };
+template <> struct SelectNodeType<Float>   { typedef ConstantFPSDNode Type; };
+
+template <char Char, typename ConstType, typename This>
+struct ConstantConstraint {
+  typedef typename SelectConstantType<ConstType>::Type ConstantType;
+  typedef typename SelectNodeType<ConstType>::Type     NodeType;
+  static const char Code = Char;
+
+  static bool check(Value const* Constant) {
+    if (ConstantType const* C = dyn_cast<ConstantType>(Constant))
+      return This::checkValue(C);
+    return false;
+  }
+  static void getConstant(SDValue Op, SelectionDAG & DAG, SDValue & Result) {
+    NodeType const* C = dyn_cast<NodeType>(Op);
+    if (not C or not This::checkValue(C))
+      return;
+
+    Result = DAG.getTargetConstant(This::get(C), SDLoc(Op), This::getValueType(Op));
+  }
+  static EVT getValueType(SDValue const& Op) { return Op.getValueType(); }
+};
+
+struct G : ConstantConstraint<'G', Float, G> {
+  template <typename T> static bool
+  checkValue(T const* C) { return C->isZero(); }
+  template <typename T> static uint64_t get(T const* C) { return 0; }
+  // Soften float to i8 0
+  static EVT getValueType(SDValue const& Op) { return MVT::i8; }
+};
+
+struct I : ConstantConstraint<'I', Integer, I> {
+  template <typename T> static bool
+  checkValue(T const* C) { return isUInt<6>(get(C)); }
+  template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
+};
+
+struct J : ConstantConstraint<'J', Integer, J> {
+  template <typename T> static bool
+  checkValue(T const* C) {
+    return (get(C) >= -63) && (get(C) <= 0);
+  }
+  template <typename T> static int64_t get(T const* C) { return C->getSExtValue(); }
+};
+
+struct K : ConstantConstraint<'K', Integer, K> {
+  template <typename T> static bool
+  checkValue(T const* C) { return get(C) == 2; }
+  template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
+};
+
+struct L : ConstantConstraint<'L', Integer, L> {
+  template <typename T> static bool
+  checkValue(T const* C) { return get(C) == 0; }
+  template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
+};
+
+struct M : ConstantConstraint<'M', Integer, M> {
+  template <typename T> static bool
+  checkValue(T const* C) { return isUInt<8>(get(C)); }
+  template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
+  static EVT getValueType(SDValue const& Op) {
+    return Op.getValueType() == MVT::i8 ? MVT::i16 : Op.getValueType();
+  }
+};
+
+struct N : ConstantConstraint<'N', Integer, N> {
+  template <typename T> static bool
+  checkValue(T const* C) { return get(C) == -1; }
+  template <typename T> static int64_t get(T const* C) { return C->getSExtValue(); }
+};
+
+struct O : ConstantConstraint<'O', Integer, O> {
+  template <typename T> static bool
+  checkValue(T const* C) { return (get(C) ==  8) || (get(C) == 16) || (get(C) == 24); }
+  template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
+};
+
+struct P : ConstantConstraint<'P', Integer, P> {
+  template <typename T> static bool
+  checkValue(T const* C) { return C->getZExtValue() == 1; }
+  template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
+};
+
+struct R : ConstantConstraint<'R', Integer, R> {
+  template <typename T> static bool
+  checkValue(T const* C) { return (get(C) >= -6) && (get(C) <= 5); }
+  template <typename T> static int64_t get(T const* C) { return C->getSExtValue(); }
+};
+  
+}}} // end of namespace llvm::AVR::Constraints
+
+#endif // LLVM_AVR_INLINE_ASM_CONSTRAINTS_H
+

--- a/lib/Target/AVR/AVRInlineAsmConstraints.h
+++ b/lib/Target/AVR/AVRInlineAsmConstraints.h
@@ -89,6 +89,8 @@ struct M : ConstantConstraint<'M', Integer, M> {
   checkValue(T const* C) { return isUInt<8>(get(C)); }
   template <typename T> static uint64_t get(T const* C) { return C->getZExtValue(); }
   static EVT getValueType(SDValue const& Op) {
+    // i8 type may be printed as a negative number, e.g. 254 would be printed
+    // as -2, so we force it to i16 at least.
     return Op.getValueType() == MVT::i8 ? MVT::i16 : Op.getValueType();
   }
 };

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -170,7 +170,7 @@ def call_target : Operand<iPTR>
 }
 
 // Addressing mode pattern reg+imm6
-def addr : ComplexPattern<iPTR, 2, "SelectAddr", [], [SDNPWantRoot]>;
+def addr : ComplexPattern<iPTR, 2, "selectAddr", [], [SDNPWantRoot]>;
 
 // AsmOperand class for a pointer register.
 // Used with the LD/ST family of instructions.

--- a/lib/Target/AVR/AVRRegisterInfo.cpp
+++ b/lib/Target/AVR/AVRRegisterInfo.cpp
@@ -76,16 +76,12 @@ const TargetRegisterClass *
 AVRRegisterInfo::getLargestLegalSuperClass(const TargetRegisterClass *RC,
                                            const MachineFunction &MF) const
 {
+  if (RC->hasType(MVT::i32))
+    return &AVR::GPR8QuadRegClass;
   if (RC->hasType(MVT::i16))
-  {
     return &AVR::DREGSRegClass;
-  }
-
   if (RC->hasType(MVT::i8))
-  {
     return &AVR::GPR8RegClass;
-  }
-
   llvm_unreachable("Invalid register size");
 }
 

--- a/lib/Target/AVR/AVRRegisterInfo.td
+++ b/lib/Target/AVR/AVRRegisterInfo.td
@@ -107,6 +107,7 @@ CoveredBySubRegs = 1 in
   def R1R0   : AVRReg<0,  "r1:r0",   [R0, R1]>,   DwarfRegNum<[0]>;
 }
 
+
 //===----------------------------------------------------------------------===//
 // Register Classes
 //===----------------------------------------------------------------------===//
@@ -214,7 +215,20 @@ def CCR : RegisterClass<"AVR", [i8], 8, (add SREG)>
 }
 
 //===----------------------------------------------------------------------===//
-// Register Classes
+// Pseudo Register Classes
 //===----------------------------------------------------------------------===//
 
+let Namespace = "AVR" in {
+  def qsub_0 : SubRegIndex<8>;
+  def qsub_1 : SubRegIndex<8, 8>;
+  def qsub_2 : SubRegIndex<8, 16>;
+  def qsub_3 : SubRegIndex<8, 24>;
+}
 
+def Tuples4r : RegisterTuples<[qsub_0, qsub_1, qsub_2, qsub_3],
+                              [(add R20, R21, R22, R23, R24, R25, R26, R27, R28),
+                               (add R21, R22, R23, R24, R25, R26, R27, R28, R29),
+                               (add R22, R23, R24, R25, R26, R27, R28, R29, R30),
+                               (add R23, R24, R25, R26, R27, R28, R29, R30, R31)]>;
+
+def GPR8Quad : RegisterClass<"AVR", [i32], 8, (add Tuples4r)>;


### PR DESCRIPTION
This is work in progress.

I started looking into inline assembly. I'm currently stuck at this test case from CodeGen/AVR/inline-asm.ll:

``` asm
; RUN: llc < %s -march=avr | FileCheck %s

; CHECK-LABEL: multibyte_i32
define void @multibyte_i32(i32 %a) {
entry:
; CHECK: instr r22 r23 r24 r25
  call void asm sideeffect "instr ${0:A} ${0:B} ${0:C} ${0:D}", "r"(i32 %a)
; CHECK: instr r25 r24 r23 r22
  call void asm sideeffect "instr ${0:D} ${0:C} ${0:B} ${0:A}", "r"(i32 %a)
  ret void
}
````

Seems like handling of i32 values is missing. I've seen a few comments along the line "We only support i8 and i16". Why is that? Could you elaborate?