### PR TITLE
Better Multiplication

### DIFF
--- a/lib/Target/AVR/AVRISelLowering.h
+++ b/lib/Target/AVR/AVRISelLowering.h
@@ -150,7 +150,7 @@ private:
   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerBlockAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerBR_CC(SDValue Op, SelectionDAG &DAG) const;
-  SDValue LowerINLINEASM(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerINLINEASM(SDValue Op, SelectionDAG &DAG) const;          
   SDValue LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSETCC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerVASTART(SDValue Op, SelectionDAG &DAG) const;
@@ -171,8 +171,10 @@ private:
                           const SmallVectorImpl<ISD::InputArg> &Ins,
                           SDLoc dl, SelectionDAG &DAG,
                           SmallVectorImpl<SDValue> &InVals) const;
-  MachineBasicBlock *EmitShiftInstr(MachineInstr *MI,
-                                    MachineBasicBlock *BB) const;
+
+private: // custom inserters 
+  MachineBasicBlock * insertShift(MachineInstr *MI,  MachineBasicBlock *BB) const;
+  MachineBasicBlock * insertMul(MachineInstr * MI, MachineBasicBlock * BB) const;
 };
 
 } // end namespace llvm

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -489,60 +489,28 @@ Defs = [SREG] in
 let isCommutable = 1,
 Defs = [R1, R0, SREG] in
 {
+}
+
+let isCommutable = 1,
+Defs = [R1, R0, SREG] in
+{
   // MUL Rd, Rr
-  // Multiplies Rd by Rr and places the result into Rd.
-  def MULRdRr : FRdRr<0b1001,
-                      0b11,
-                      (outs),
-                      (ins GPR8:$lhs, GPR8:$rhs),
-                      "mul\t$lhs, $rhs",
-                      []>,
-                Requires<[SupportsMultiplication]>;
+  // Multiplies Rd by Rr and places the result into R1:R0.
+  let usesCustomInserter = 1 in {
+    def MULRdRr : FRdRr<0b1001, 0b11,
+                        (outs),
+                        (ins GPR8:$lhs, GPR8:$rhs),
+                        "mul\t$lhs, $rhs",
+                        [/*(set R1, R0, (smullohi GPR8:$lhs, GPR8:$rhs))*/]>,
+                    Requires<[SupportsMultiplication]>;
 
-  // MULW DST+1:DST, LHS+1:LHS, RHS+1:RHS
-  //
-  // The earlyclobber flag is required because the pseudo expansion needs $rd
-  // and $src to have different registers.
-  //
-  // Expands to:
-  // mul  LHS, RHS
-  // movw DST+1:DST, r1:r0
-  // mul  LHS, RHS+1
-  // add  DST+1, r0
-  // mul  LHS+1, RHS
-  // add  DST+1, r0
-  // clr r1
-  let Constraints = "@earlyclobber $dst" in
-  def MULWRdRr : Pseudo<(outs DREGS:$dst),
-                        (ins DREGS:$lhs, DREGS:$rhs),
-                        "mulw\t$dst, $lhs, $rhs",
-                        [(set DREGS:$dst, (mul DREGS:$lhs, DREGS:$rhs)),
-                         (implicit SREG)]>,
-                 Requires<[SupportsMultiplication]>;
-
-  // MULP Rd, Rr
-  //
-  // This pseudo is used as a marker to insert a "clr r1" after the operation.
-  //
-  // Expands to:
-  // mul Rd, Rr
-  // mov Rd, r0
-  // clr r1
-  let Constraints = "$src = $rd" in
-  def MULRdRrP : Pseudo<(outs GPR8:$rd),
-                        (ins GPR8:$src, GPR8:$rr),
-                        "mulp\t$rd, $src, $rr",
-                        [(set GPR8:$rd, (mul GPR8:$src, GPR8:$rr)),
-                         (implicit SREG)]>,
-                 Requires<[SupportsMultiplication]>;
-
-
-  def MULSRdRr : FMUL2RdRr<0,
-                           (outs),
-                           (ins GPR8:$lhs, GPR8:$rhs),
-                           "muls\t$lhs, $rhs",
-                           []>,
-                 Requires<[SupportsMultiplication]>;
+    def MULSRdRr : FMUL2RdRr<0,
+                             (outs),
+                             (ins GPR8:$lhs, GPR8:$rhs),
+                             "muls\t$lhs, $rhs",
+                             []>,
+                   Requires<[SupportsMultiplication]>;
+  }
 
   def MULSURdRr : FMUL2RdRr<1,
                             (outs),
@@ -1695,7 +1663,7 @@ Defs = [SREG] in
 // Alias for EOR Rd, Rd
 // -------------
 // Clears all bits in a register.
-def : InstAlias<"clr\t$rd", (EORRdRr GPR8:$rd, GPR8:$rd)>;
+def CLR : InstAlias<"clr\t$rd", (EORRdRr GPR8:$rd, GPR8:$rd)>;
 
 // SER Rd
 // Alias for LDI Rd, 0xff
@@ -1984,6 +1952,7 @@ def : Pat<(i16 (AVRWrapper tblockaddress:$dst)),
 // hi-reg truncation : trunc(int16 >> 8)
 //:FIXME: i think it's better to emit an extract subreg node in the DAG than
 // all this mess once we get optimal shift code
+// lol... I think so, too. [@agnat]
 def : Pat<(i8 (trunc (AVRlsr (AVRlsr (AVRlsr (AVRlsr (AVRlsr (AVRlsr (AVRlsr
                      (AVRlsr DREGS:$src)))))))))),
           (EXTRACT_SUBREG DREGS:$src, sub_hi)>;
@@ -1992,3 +1961,4 @@ def : Pat<(i8 (trunc (AVRlsr (AVRlsr (AVRlsr (AVRlsr (AVRlsr (AVRlsr (AVRlsr
 // BR_JT -> (mul x, 2) -> (shl x, 1)
 def : Pat<(shl DREGS:$src1, (i8 1)),
           (LSLWRd DREGS:$src1)>;
+

--- a/test/CodeGen/AVR/mul.ll
+++ b/test/CodeGen/AVR/mul.ll
@@ -1,25 +1,28 @@
 ; RUN: llc -mattr=mul,movw < %s -march=avr | FileCheck %s
-; XFAIL: *
 
 define i8 @mult8(i8 %a, i8 %b) {
 ; CHECK-LABEL: mult8:
-; CHECK: mul r22, r24
-; CHECK: mov r24, r0
-; :TODO: clr r1
+; CHECK: muls r22, r24
+; CHECK: eor  r1, r1
+; CHECK: mov  r24, r0
   %mul = mul i8 %b, %a
   ret i8 %mul
 }
 
 define i16 @mult16(i16 %a, i16 %b) {
 ; CHECK-LABEL: mult16:
-; CHECK: mul r22, r24
-; CHECK: movw r18, r0
-; CHECK: mul r22, r25
-; CHECK: add r19, r0
-; CHECK: mul r23, r24
-; CHECK: add r19, r0
-; CHECK: movw r24, r18
-; :TODO: clr r1
+; CHECK: muls r22, r25
+; CHECK: mov  r18, r0
+; CHECK: mul  r22, r24
+; CHECK: mov  r19, r0
+; CHECK: mov  r20, r1
+; CHECK: eor  r1,  r1
+; CHECK: add  r20, r18
+; CHECK: muls r23, r24
+; CHECK: eor  r1,  r1
+; CHECK: mov  r22, r0
+; CHECK: add  r22, r20
+; :TODO: finish after reworking shift instructions
   %mul = mul nsw i16 %b, %a
   ret i16 %mul
 }


### PR DESCRIPTION
Sorry for being longish, but I think it is important to share my thoughts...

So... As mentioned in #126 I believe pseudo instructions are not the way to go. Instead of guiding the initial lowering towards instructions we actually support we encourage the emission of instructions we don't have. Down the pipeline we have trouble expanding these pseudos, because we suddenly have to do this weird manual register lifetime management, which is error prone and... overall pretty disgusting.

I also believe it is bad for optimization. We do not describe the _actual_ instruction set. We create a new _virtual_ instruction set, which hides the details.

Let's try something else. Looking at the AVR `mul` instructions they are a lot closer to the [`ISD::MUL_LOHI`](https://github.com/avr-llvm/llvm/blob/avr-support/include/llvm/CodeGen/ISDOpcodes.h#L188-L191) operations. So, I disabled `mul` altogether, requesting expansion and indeed LLVM started emitting `UMUL_LOHI/SMUL_LOHI` nodes instead. A piece of custom selection code inserts copy-register-nodes at the SelectionDAG level to save the results. That frees us from doing manual lifetime management.

Time to look at the _actual_ bug. The multiplication instructions write to R1, our zero reg and leave it ... non zero. We need to clear it _after_ moving the result. I failed to express this on the SelectionDAG level, because I do not grok the control-flow-graph yet. I currently use a custom inserter. It looks for the `mov` instructions following our `mul` and injects an `eor r1 r1`. Here is what an `i8 mul` look like:

````
	muls	r22, r24
	eor	r1, r1
	mov	r24, r0

````

Note, that the optimizer moved the `eor` .

To support larger types we tell LLVM to expand those operations:

````
  setOperationAction(ISD::SMUL_LOHI, MVT::i16, Expand);
  setOperationAction(ISD::UMUL_LOHI, MVT::i16, Expand);
````

Let's have a look at the assembly for a i16 `mul`:

````
	muls	r22, r25
	mov	r18, r0
	eor	r1, r1
	mul	r22, r24
	mov	r19, r0
	mov	r20, r1
	eor	r1, r1      // <= NOT moved by optimizer :)
	add	r20, r18
	muls	r23, r24
	eor	r1, r1
	mov	r22, r0
	add	r22, r20
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	lsl	r22
	rol	r23
	mov	r24, r19
	eor	r25, r25
	or	r24, r22
	or	r25, r23

````

Ignoring the obvious flaw, that actually looks pretty ok. 

Looking at other targets, they do a lot more work in `*ISelLowering` and `*ISelDAGToDAG`. No other target has a pseudo instruction expansion pass like we do. I think we should try to migrate away from pseudos, instead of following that (IMHO flawed) scheme. This is a first step.

What do you think?

