### PR TITLE
Experimental: Unleash code generation

### DIFF
--- a/lib/Target/AVR/AVRCallingConv.td
+++ b/lib/Target/AVR/AVRCallingConv.td
@@ -16,10 +16,7 @@
 def RetCC_AVR : CallingConv
 <[
   // i8 is returned in R24.
-  CCIfType<[i8], CCAssignToReg<[R24]>>,
-
-  // i16 are returned in R25:R24, R23:R22, R21:R20 and R19:R18.
-  CCIfType<[i16], CCAssignToReg<[R25R24, R23R22, R21R20, R19R18]>>
+  CCIfType<[i8], CCAssignToReg<[R24, R23, R22, R21, R20, R19, R18, R17, R16, R15, R14, R13, R12, R11, R10, R9, R8]>>
 ]>;
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/AVR/AVRISelDAGToDAG.cpp
+++ b/lib/Target/AVR/AVRISelDAGToDAG.cpp
@@ -31,7 +31,7 @@ namespace llvm {
 
 class AVRDAGToDAGISel : public SelectionDAGISel {
 public:
-  explicit AVRDAGToDAGISel(AVRTargetMachine &tm, CodeGenOpt::Level OptLevel) :
+  AVRDAGToDAGISel(AVRTargetMachine &tm, CodeGenOpt::Level OptLevel) :
     SelectionDAGISel(tm, OptLevel), Subtarget(nullptr) {}
 
   const char *getPassName() const override

--- a/lib/Target/AVR/AVRISelLowering.h
+++ b/lib/Target/AVR/AVRISelLowering.h
@@ -154,6 +154,7 @@ private:
   SDValue LowerSELECT_CC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerSETCC(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerVASTART(SDValue Op, SelectionDAG &DAG) const;
+  SDValue lowerLoad(SDValue Op, SelectionDAG &DAG) const;
 
   SDValue LowerReturn(SDValue Chain, CallingConv::ID CallConv, bool isVarArg,
                       const SmallVectorImpl<ISD::OutputArg> &Outs,
@@ -172,7 +173,7 @@ private:
                           SDLoc dl, SelectionDAG &DAG,
                           SmallVectorImpl<SDValue> &InVals) const;
 
-private: // custom inserters 
+private: // custom inserters
   MachineBasicBlock * insertShift(MachineInstr *MI,  MachineBasicBlock *BB) const;
   MachineBasicBlock * insertMul(MachineInstr * MI, MachineBasicBlock * BB) const;
 };


### PR DESCRIPTION
Looking a bit deeper into the whole SelectionDAG business  I believe this is the root of all evil:

````
addRegisterClass(MVT::i16, &AVR::DREGSRegClass);
````

It makes LLVM believe i16 is a native type. So I ripped it out.

The part that immediately collapsed is the calling convention. I kind of kludged the kludge and it works for now (as in: it compiles). But it certainly has bugs. The whole calling convention could use some love...

The other issue is probably a little more involved. LLVM does not provide any help when the targets pointer type is larger than the targets native registers. I'll look into that.

Demo? Sure thing:

### 16 Bit Multiplication

````
	muls	r21, r24
	mov	r24, r0
	eor	r1, r1
	mul	r21, r23
	mov	r25, r0
	mov	r18, r1
	eor	r1, r1
	add	r18, r24
	muls	r22, r23
	eor	r1, r1
	mov	r24, r0
	add	r24, r18
	mov	r23, r25
````

No more crazy shifting.

### 64 Bit And

````
	push	r17
	andi	r17, -3
	andi	r19, -101
	andi	r20, 88
	andi	r21, 76
	andi	r22, 73
	andi	r23, 31
	andi	r24, -14
	pop	r17
	ret
````

Everything fits in registers and is done in place.