### PR TITLE
Division/remainder support

### DIFF
--- a/include/llvm/IR/CallingConv.h
+++ b/include/llvm/IR/CallingConv.h
@@ -150,7 +150,14 @@ namespace CallingConv {
     AVR_INTR = 81,
     
     /// AVR_SIGNAL - Calling convention used for AVR signal routines.
-    AVR_SIGNAL = 82
+    AVR_SIGNAL = 82,
+
+    /// Calling convention used for special multiplication RTLIB routines.
+    AVR_RT_MUL = 83,
+
+    /// Calling convention used for special division RTLIB routines.
+    AVR_RT_DIV = 84
+
   };
 } // End CallingConv namespace
 

--- a/lib/Target/AVR/AVRCallingConv.td
+++ b/lib/Target/AVR/AVRCallingConv.td
@@ -22,6 +22,13 @@ def RetCC_AVR : CallingConv
   CCIfType<[i16], CCAssignToReg<[R25R24, R23R22, R21R20, R19R18]>>
 ]>;
 
+// Special return value calling convention for runtime functions.
+def RetCC_AVR_RT : CallingConv
+<[
+  CCIfType<[i8], CCAssignToReg<[R24,R25]>>,
+  CCIfType<[i16], CCAssignToReg<[R23R22, R25R24]>>
+]>;
+
 //===----------------------------------------------------------------------===//
 // AVR Argument Calling Conventions
 //===----------------------------------------------------------------------===//
@@ -29,10 +36,25 @@ def RetCC_AVR : CallingConv
 // The calling conventions are implemented in custom C++ code
 
 // Calling convention for variadic functions.
-def CC_AVR_Vararg : CallingConv
+def ArgCC_AVR_Vararg : CallingConv
 <[
   // i16 are always passed through the stack with an alignment of 1.
   CCAssignToStack<2, 1>
+]>;
+
+// Special argument calling convention for
+// multiplication runtime functions.
+def ArgCC_AVR_RT_MUL : CallingConv
+<[
+  CCIfType<[i16], CCAssignToReg<[R27R26,R19R18]>>
+]>;
+
+// Special argument calling convention for
+// division runtime functions.
+def ArgCC_AVR_RT_DIV : CallingConv
+<[
+  CCIfType<[i8], CCAssignToReg<[R24,R22]>>,
+  CCIfType<[i16], CCAssignToReg<[R25R24, R23R22]>>
 ]>;
 
 //===----------------------------------------------------------------------===//

--- a/lib/Target/AVR/AVRISelLowering.h
+++ b/lib/Target/AVR/AVRISelLowering.h
@@ -148,6 +148,7 @@ private:
   SDValue getAVRCmp(SDValue LHS, SDValue RHS, ISD::CondCode CC, SDValue &AVRcc,
                     SelectionDAG &DAG, SDLoc dl) const;
   SDValue LowerShifts(SDValue Op, SelectionDAG &DAG) const;
+  SDValue LowerDivRem(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerGlobalAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerBlockAddress(SDValue Op, SelectionDAG &DAG) const;
   SDValue LowerBR_CC(SDValue Op, SelectionDAG &DAG) const;
@@ -159,14 +160,14 @@ private:
   SDValue LowerReturn(SDValue Chain, CallingConv::ID CallConv, bool isVarArg,
                       const SmallVectorImpl<ISD::OutputArg> &Outs,
                       const SmallVectorImpl<SDValue> &OutVals, SDLoc dl,
-                      SelectionDAG &DAG) const;
+                      SelectionDAG &DAG) const override;
   SDValue LowerFormalArguments(SDValue Chain, CallingConv::ID CallConv,
                                bool isVarArg,
                                const SmallVectorImpl<ISD::InputArg> &Ins,
                                SDLoc dl, SelectionDAG &DAG,
-                               SmallVectorImpl<SDValue> &InVals) const;
+                               SmallVectorImpl<SDValue> &InVals) const override;
   SDValue LowerCall(TargetLowering::CallLoweringInfo &CLI,
-                    SmallVectorImpl<SDValue> &InVals) const;
+                    SmallVectorImpl<SDValue> &InVals) const override;
   SDValue LowerCallResult(SDValue Chain, SDValue InFlag,
                           CallingConv::ID CallConv, bool isVarArg,
                           const SmallVectorImpl<ISD::InputArg> &Ins,

--- a/test/CodeGen/AVR/div.ll
+++ b/test/CodeGen/AVR/div.ll
@@ -1,0 +1,54 @@
+; RUN: llc -mattr=mul,movw < %s -march=avr | FileCheck %s
+
+; Unsigned 8-bit division
+define i8 @udiv8(i8 %a, i8 %b) {
+; CHECK-LABEL: div8:
+; CHECK: mov r25, r24
+; CHECK: mov r24, r22
+; CHECK: mov r22, r25
+; CHECK: call __udivmodqi4
+; CHECK: mov r24, r25
+; CHECK: ret
+
+  %quotient = udiv i8 %b, %a
+  ret i8 %quotient
+}
+
+; Signed 8-bit division
+define i8 @sdiv8(i8 %a, i8 %b) {
+; CHECK-LABEL: sdiv8:
+; CHECK: mov r25, r24
+; CHECK: mov r24, r22
+; CHECK: mov r22, r25
+; CHECK: call __divmodqi4
+; CHECK: mov r24, r25
+; CHECK: ret
+
+  %quotient = sdiv i8 %b, %a
+  ret i8 %quotient
+}
+
+; Unsigned 16-bit division
+define i16 @udiv16(i16 %a, i16 %b) {
+; CHECK-LABEL: udiv16:
+; CHECK: movw r18, r24
+; CHECK: movw r24, r22
+; CHECK: movw r22, r18
+; CHECK: call __udivmodhi4
+; CHECK: ret
+  %quot = udiv i16 %b, %a
+  ret i16 %quot
+}
+
+; Signed 16-bit division
+define i16 @sdiv16(i16 %a, i16 %b) {
+; CHECK-LABEL: sdiv16:
+; CHECK: movw r18, r24
+; CHECK: movw r24, r22
+; CHECK: movw r22, r18
+; CHECK: call __divmodhi4
+; CHECK: ret
+  %quot = sdiv i16 %b, %a
+  ret i16 %quot
+}
+


### PR DESCRIPTION
This is a work-in-progress patch for adding division support (by calling runtime library functions).

AVR's `libgcc` does not implement division routines - it more or less only implements division and remainder functions.

This patch allows `LegalizeDAG.cpp` to expand a `DIV` or `REM` node into a `DIVREM` node, throwing away one of the results. It also adds a special calling convention for AVR runtime library functions.

The problem is then lowering the `DIVREM` node into a correct call of `__udivmodqi4`, `__divmodsi4`, etc.

I can find two different ways:

* Use the existing `expandDivRemLibcall` code in `LegalizeDAG.cpp` to generate a call. The problem with this is that the DIVREM libcall is the only (I think) libcall which returns two results. `LegalizeDAG` works around this by assuming the calling convention of the `DIVREM` libcall - the quotient is returned as normal - whatever the AVR calling convention suggests, but the address of the remainder is passed as an argument. This works for most targets, but not AVR. This problem has been faced before - see [this](https://groups.google.com/forum/#!topic/llvm-dev/Il_yZJqiQSM) mailing list post (in which the assumed calling conv. was not the valid ARM EABI calling convention).
* Set the `LegalizeAction` for `DIVREM` to `Custom` so that we can manually handle it in `AVRTargetLowering::LowerOperation`. There are two pitfalls. 1) custom lowering with multiple results is messy (see [`LegalizeDAG.cpp`](https://github.com/avr-llvm/llvm/blob/avr-support/lib/CodeGen/SelectionDAG/LegalizeDAG.cpp#L1346)). 2) Not all DIVREM routines have a special calling convention - some are written in regular C (not asm) and follow the normal calling convention.

@agnat What are your thoughts?