### PR TITLE
[AVR] Touch up fixups

### DIFF
--- a/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.h
+++ b/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.h
@@ -39,8 +39,8 @@ public:
   /**
    * Adjusts a fixup value before it is applied.
    */
-  uint64_t adjustFixupValue(const MCFixup &Fixup, uint64_t Value,
-                            MCContext *Ctx = nullptr) const;
+  void adjustFixupValue(const MCFixup &Fixup, uint64_t & Value,
+                        MCContext *Ctx = nullptr) const;
 
   MCObjectWriter *createObjectWriter(raw_pwrite_stream &OS) const override;
 

--- a/lib/Target/AVR/MCTargetDesc/AVRFixupKinds.h
+++ b/lib/Target/AVR/MCTargetDesc/AVRFixupKinds.h
@@ -82,12 +82,12 @@ enum Fixups {
 
 namespace fixups {
 
-template<typename T> inline T adjustRelativeBranchTarget(T val) {
-  return val >> 1;
+template <typename T> inline void adjustRelativeBranchTarget(T & val) {
+  val >>= 1;
 }
 
-template<typename T> inline T adjustBranchTarget(T val) {
-  return val >> 1;
+template <typename T> inline void adjustBranchTarget(T & val) {
+  val >>= 1;
 }
 
 } // end of namespace fixups

--- a/lib/Target/AVR/MCTargetDesc/AVRMCCodeEmitter.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRMCCodeEmitter.cpp
@@ -104,13 +104,13 @@ AVRMCCodeEmitter::encodeRelCondBrTarget(const MCInst &MI, unsigned OpNo,
     const MCExpr *Expr = MO.getExpr();
     Fixups.push_back(MCFixup::create(0, Expr, MCFixupKind(Fixup), MI.getLoc()));
     return 0;
-  } else {
-    // take the size of the current instruction away.
-    // with labels, this is implicitly handled.
-    auto target = MO.getImm();
-
-    return AVR::fixups::adjustRelativeBranchTarget(target);
   }
+
+  // take the size of the current instruction away.
+  // with labels, this is implicitly handled.
+  auto target = MO.getImm();
+  AVR::fixups::adjustRelativeBranchTarget(target);
+  return target;
 }
 
 unsigned
@@ -162,7 +162,9 @@ AVRMCCodeEmitter::encodeCallTarget(const MCInst &MI, unsigned OpNo,
     Fixups.push_back(MCFixup::create(0, MO.getExpr(), FixupKind, MI.getLoc()));
     return 0;
   }
-  return AVR::fixups::adjustBranchTarget(MO.getImm());
+  auto target = MO.getImm();
+  AVR::fixups::adjustBranchTarget(target);
+  return target;
 }
 
 


### PR DESCRIPTION
Pass fixup value by reference to adjustFooBar(...) functions, adjusting the value in-place. Drop a missleading comment in processFixupValue(...).

I think it's a little less confusing this way... @dylanmckay, could you give it a review and maybe re-run your test case?