### PR TITLE
Fix branch handling code

### DIFF
--- a/lib/Target/AVR/AsmParser/AVRAsmParser.cpp
+++ b/lib/Target/AVR/AsmParser/AVRAsmParser.cpp
@@ -435,11 +435,7 @@ AVRAsmParser::parseOperand(OperandVector &Operands) {
       }
     case AsmToken::LParen:
     case AsmToken::Integer:
-      return tryParseExpression(Operands);
-
     case AsmToken::Dot:
-      // Parse the '.[+-]offset' syntax for PC-relative call.
-      Parser.Lex(); // Eat `.`
       return tryParseExpression(Operands);
 
     case AsmToken::Plus:

--- a/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
@@ -16,6 +16,7 @@
 #include "llvm/MC/MCAsmBackend.h"
 #include "llvm/MC/MCAssembler.h"
 #include "llvm/MC/MCContext.h"
+#include "llvm/MC/MCValue.h"
 #include "llvm/MC/MCDirectives.h"
 #include "llvm/MC/MCELFObjectWriter.h"
 #include "llvm/MC/MCFixupKindInfo.h"
@@ -56,8 +57,6 @@ void
 adjustRelativeBranch(unsigned Size, const MCFixup &Fixup,
                      T &Value, MCContext *Ctx = nullptr)
 {
-  // For relative branches, we must subtract the size of
-  // the current instruction.
   Value -= 2;
 
   adjustBranch(Size, Fixup, Value, Ctx);
@@ -354,6 +353,14 @@ AVRAsmBackend::processFixupValue(const MCAssembler &Asm,
                                  uint64_t &Value,
                                  bool &IsResolved)
 {
+  // Parsed LLVM-generated temporary labels are already
+  // adjusted for instruction size, but normal labels aren't.
+  //
+  // To handle both cases, we simply un-adjust the temporary label
+  // case so it acts like all other labels.
+  if(Target.getSymA()->getSymbol().isTemporary())
+    Value += 2;
+
   adjustFixupValue(Fixup, Value, &Asm.getContext());
 }
 

--- a/test/MC/AVR/inst-brbc.s
+++ b/test/MC/AVR/inst-brbc.s
@@ -6,6 +6,8 @@ foo:
   brbc 3, .+8
   brbc 0, .-16
 
-; CHECK: brvc .+8                   ; encoding: [0x23,0xf4]
-; CHECK: brcc .-16                  ; encoding: [0xc0,0xf7]
+; CHECK: brvc .Ltmp0+8              ; encoding: [0bAAAAA011,0b111101AA]
+; CHECK:                            ; fixup A - offset: 0, value: .Ltmp0+8, kind: fixup_7_pcrel
+; CHECK: brcc .Ltmp1-16             ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                            ; fixup A - offset: 0, value: .Ltmp1-16, kind: fixup_7_pcrel
 

--- a/test/MC/AVR/inst-brbs.s
+++ b/test/MC/AVR/inst-brbs.s
@@ -6,6 +6,8 @@ foo:
   brbs 3, .+8
   brbs 0, .-12
 
-; CHECK: brvs .+8                   ; encoding: [0x23,0xf0]
-; CHECK: brcs .-12                  ; encoding: [0xd0,0xf3]
+; CHECK: brvs .Ltmp0+8              ; encoding: [0bAAAAA011,0b111100AA]
+; CHECK:                            ; fixup A - offset: 0, value: .Ltmp0+8, kind: fixup_7_pcrel
+; CHECK: brcs .Ltmp1-12             ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                            ; fixup A - offset: 0, value: .Ltmp1-12, kind: fixup_7_pcrel
 

--- a/test/MC/AVR/inst-family-cond-branch.s
+++ b/test/MC/AVR/inst-family-cond-branch.s
@@ -9,11 +9,29 @@ foo:
   brbs 1, .-18
   brbs 1, baz
   
+; CHECK: breq    .Ltmp0-18               ; encoding: [0bAAAAA001,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp0-18, kind: fixup_7_pcrel
+; CHECK: breq    .Ltmp1-12               ; encoding: [0bAAAAA001,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp1-12, kind: fixup_7_pcrel
+; CHECK: brbs    1, .Ltmp2-18            ; encoding: [0bAAAAA001,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp2-18, kind: fixup_7_pcrel
+; CHECK: brbs    1, baz                  ; encoding: [0bAAAAA001,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: baz, kind: fixup_7_pcrel
+
   ; BRNE
   brne .+10
   brne .+2
   brbc 1, .+10
   brbc 1, bar
+
+; CHECK: brne    .Ltmp3+10               ; encoding: [0bAAAAA001,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp3+10, kind: fixup_7_pcrel
+; CHECK: brne    .Ltmp4+2                ; encoding: [0bAAAAA001,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp4+2, kind: fixup_7_pcrel
+; CHECK: brbc    1, .Ltmp5+10            ; encoding: [0bAAAAA001,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp5+10, kind: fixup_7_pcrel
+; CHECK: brbc    1, bar                  ; encoding: [0bAAAAA001,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: bar, kind: fixup_7_pcrel
 
 bar:
   
@@ -23,16 +41,41 @@ bar:
   brbs 0, .+8
   brbs 0, end
   
+; CHECK: brcs    .Ltmp6+8                ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp6+8, kind: fixup_7_pcrel
+; CHECK: brcs    .Ltmp7+4                ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp7+4, kind: fixup_7_pcrel
+; CHECK: brcs    .Ltmp8+8                ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp8+8, kind: fixup_7_pcrel
+; CHECK: brcs    end                     ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
   ; BRCC
   brcc .+66
   brcc .-22
   brbc 0, .+66
   brbc 0, baz
   
+; CHECK: brcc    .Ltmp9+66               ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp9+66, kind: fixup_7_pcrel
+; CHECK: brcc    .Ltmp10-22              ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp10-22, kind: fixup_7_pcrel
+; CHECK: brcc    .Ltmp11+66              ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp11+66, kind: fixup_7_pcrel
+; CHECK: brcc    baz                     ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: baz, kind: fixup_7_pcrel
+
   ; BRSH
   brsh .+32
   brsh .+70
   brsh car
+
+; CHECK: brsh    .Ltmp12+32              ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp12+32, kind: fixup_7_pcrel
+; CHECK: brsh    .Ltmp13+70              ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp13+70, kind: fixup_7_pcrel
+; CHECK: brsh    car                     ; encoding: [0bAAAAA000,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
 
 baz:
 
@@ -41,20 +84,48 @@ baz:
   brlo .+28
   brlo car
   
+; CHECK: brlo    .Ltmp14+12              ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp14+12, kind: fixup_7_pcrel
+; CHECK: brlo    .Ltmp15+28              ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp15+28, kind: fixup_7_pcrel
+; CHECK: brlo    car                     ; encoding: [0bAAAAA000,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
+
   ; BRMI
   brmi .+66
   brmi .+58
   brmi car
   
+; CHECK: brmi    .Ltmp16+66              ; encoding: [0bAAAAA010,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp16+66, kind: fixup_7_pcrel
+; CHECK: brmi    .Ltmp17+58              ; encoding: [0bAAAAA010,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp17+58, kind: fixup_7_pcrel
+; CHECK: brmi    car                     ; encoding: [0bAAAAA010,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
+
   ; BRPL
   brpl .-12
   brpl .+18
   brpl car
   
+; CHECK: brpl    .Ltmp18-12              ; encoding: [0bAAAAA010,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp18-12, kind: fixup_7_pcrel
+; CHECK: brpl    .Ltmp19+18              ; encoding: [0bAAAAA010,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp19+18, kind: fixup_7_pcrel
+; CHECK: brpl    car                     ; encoding: [0bAAAAA010,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
+
   ; BRGE
   brge .+50
   brge .+42
   brge car
+
+; CHECK: brge    .Ltmp20+50              ; encoding: [0bAAAAA100,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp20+50, kind: fixup_7_pcrel
+; CHECK: brge    .Ltmp21+42              ; encoding: [0bAAAAA100,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp21+42, kind: fixup_7_pcrel
+; CHECK: brge    car                     ; encoding: [0bAAAAA100,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
 
 car:
   
@@ -63,20 +134,49 @@ car:
   brlt .+2
   brlt end
   
+; CHECK: brlt    .Ltmp22+16              ; encoding: [0bAAAAA100,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp22+16, kind: fixup_7_pcrel
+; CHECK: brlt    .Ltmp23+2               ; encoding: [0bAAAAA100,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp23+2, kind: fixup_7_pcrel
+; CHECK: brlt    end                     ; encoding: [0bAAAAA100,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
   ; BRHS
   brhs .-66
   brhs .+14
   brhs just_another_label
   
+
+; CHECK: brhs    .Ltmp24-66              ; encoding: [0bAAAAA101,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp24-66, kind: fixup_7_pcrel
+; CHECK: brhs    .Ltmp25+14              ; encoding: [0bAAAAA101,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp25+14, kind: fixup_7_pcrel
+; CHECK: brhs    just_another_label      ; encoding: [0bAAAAA101,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: just_another_label, kind: fixup_7_pcrel
+
   ; BRHC
   brhc .+12
   brhc .+14
   brhc just_another_label
   
+; CHECK: brhc    .Ltmp26+12              ; encoding: [0bAAAAA101,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp26+12, kind: fixup_7_pcrel
+; CHECK: brhc    .Ltmp27+14              ; encoding: [0bAAAAA101,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp27+14, kind: fixup_7_pcrel
+; CHECK: brhc    just_another_label      ; encoding: [0bAAAAA101,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: just_another_label, kind: fixup_7_pcrel
+
   ; BRTS
   brts .+18
   brts .+22
   brts just_another_label
+
+; CHECK: brts    .Ltmp28+18              ; encoding: [0bAAAAA110,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp28+18, kind: fixup_7_pcrel
+; CHECK: brts    .Ltmp29+22              ; encoding: [0bAAAAA110,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp29+22, kind: fixup_7_pcrel
+; CHECK: brts    just_another_label      ; encoding: [0bAAAAA110,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: just_another_label, kind: fixup_7_pcrel
 
 just_another_label:
   
@@ -85,137 +185,60 @@ just_another_label:
   brtc .+50
   brtc end
   
+; CHECK: brtc    .Ltmp30+52              ; encoding: [0bAAAAA110,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp30+52, kind: fixup_7_pcrel
+; CHECK: brtc    .Ltmp31+50              ; encoding: [0bAAAAA110,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp31+50, kind: fixup_7_pcrel
+; CHECK: brtc    end                     ; encoding: [0bAAAAA110,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
   ; BRVS
   brvs .+18
   brvs .+32
   brvs end
   
+; CHECK: brvs    .Ltmp32+18              ; encoding: [0bAAAAA011,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp32+18, kind: fixup_7_pcrel
+; CHECK: brvs    .Ltmp33+32              ; encoding: [0bAAAAA011,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp33+32, kind: fixup_7_pcrel
+; CHECK: brvs    end                     ; encoding: [0bAAAAA011,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
   ; BRVC
   brvc .-28
   brvc .-62
   brvc end
   
+; CHECK: brvc    .Ltmp34-28              ; encoding: [0bAAAAA011,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp34-28, kind: fixup_7_pcrel
+; CHECK: brvc    .Ltmp35-62              ; encoding: [0bAAAAA011,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp35-62, kind: fixup_7_pcrel
+; CHECK: brvc    end                     ; encoding: [0bAAAAA011,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
   ; BRIE
   brie .+20
   brie .+40
   brie end
   
+; CHECK: brie    .Ltmp36+20              ; encoding: [0bAAAAA111,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp36+20, kind: fixup_7_pcrel
+; CHECK: brie    .Ltmp37+40              ; encoding: [0bAAAAA111,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp37+40, kind: fixup_7_pcrel
+; CHECK: brie    end                     ; encoding: [0bAAAAA111,0b111100AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
   ; BRID
   brid .+42
   brid .+62
   brid end
 
+; CHECK: brid    .Ltmp38+42              ; encoding: [0bAAAAA111,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp38+42, kind: fixup_7_pcrel
+; CHECK: brid    .Ltmp39+62              ; encoding: [0bAAAAA111,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp39+62, kind: fixup_7_pcrel
+; CHECK: brid    end                     ; encoding: [0bAAAAA111,0b111101AA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
+
 end:
-  
 
-; BREQ
-; CHECK: breq .-18                  ; encoding: [0xb9,0xf3]
-; CHECK: breq .-12                  ; encoding: [0xd1,0xf3]
-; CHECK: brbs 1, .-18               ; encoding: [0xb9,0xf3]
-; CHECK: brbs 1, baz                ; encoding: [0bAAAAA001,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: baz, kind: fixup_7_pcrel
-
-; BRNE
-; CHECK: brne .+10                  ; encoding: [0x29,0xf4]
-; CHECK: brne .+2                   ; encoding: [0x09,0xf4]
-; CHECK: brbc 1, .+10               ; encoding: [0x29,0xf4]
-; CHECK: brbc 1, bar                ; encoding: [0bAAAAA001,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: bar, kind: fixup_7_pcrel
-
-; BRCS
-; CHECK: brcs  .+8                  ; encoding: [0x20,0xf0]
-; CHECK: brcs  .+4                  ; encoding: [0x10,0xf0]
-; CHECK: brcs  .+8                  ; encoding: [0x20,0xf0]
-; CHECK: brcs  end                  ; encoding: [0bAAAAA000,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
-
-; BRCC
-; CHECK: brcc .+66                  ; encoding: [0x08,0xf5]
-; CHECK: brcc .-22                  ; encoding: [0xa8,0xf7]
-; CHECK: brcc .+66                  ; encoding: [0x08,0xf5]
-; CHECK: brcc baz                   ; encoding: [0bAAAAA000,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: baz, kind: fixup_7_pcrel
-
-; BRSH
-; CHECK: brsh .+32                  ; encoding: [0x80,0xf4]
-; CHECK: brsh .+70                  ; encoding: [0x18,0xf5]
-; CHECK: brsh car                   ; encoding: [0bAAAAA000,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
-
-; BRLO
-; CHECK: brlo .+12                  ; encoding: [0x30,0xf0]
-; CHECK: brlo .+28                  ; encoding: [0x70,0xf0]
-; CHECK: brlo car                   ; encoding: [0bAAAAA000,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
-
-; BRMI
-; CHECK: brmi .+66                  ; encoding: [0x0a,0xf1]
-; CHECK: brmi .+58                  ; encoding: [0xea,0xf0]
-; CHECK: brmi car                   ; encoding: [0bAAAAA010,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
-
-; BRPL
-; CHECK: brpl .-12                  ; encoding: [0xd2,0xf7]
-; CHECK: brpl .+18                  ; encoding: [0x4a,0xf4]
-; CHECK: brpl car                   ; encoding: [0bAAAAA010,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
-
-; BRGE
-; CHECK: brge .+50                  ; encoding: [0xcc,0xf4]
-; CHECK: brge .+42                  ; encoding: [0xac,0xf4]
-; CHECK: brge car                   ; encoding: [0bAAAAA100,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: car, kind: fixup_7_pcrel
-
-; BRLT
-; CHECK: brlt .+16                  ; encoding: [0x44,0xf0]
-; CHECK: brlt .+2                   ; encoding: [0x0c,0xf0]
-; CHECK: brlt end                   ; encoding: [0bAAAAA100,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
-
-; BRHS
-; CHECK: brhs .-66                  ; encoding: [0xfd,0xf2]
-; CHECK: brhs .+14                  ; encoding: [0x3d,0xf0]
-; CHECK: brhs just_another_label    ; encoding: [0bAAAAA101,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: just_another_label, kind: fixup_7_pcrel
-
-; BRHC
-; CHECK: brhc .+12                  ; encoding: [0x35,0xf4]
-; CHECK: brhc .+14                  ; encoding: [0x3d,0xf4]
-; CHECK: brhc just_another_label    ; encoding: [0bAAAAA101,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: just_another_label, kind: fixup_7_pcrel
-
-; BRTS
-; CHECK: brts .+18                  ; encoding: [0x4e,0xf0]
-; CHECK: brts .+22                  ; encoding: [0x5e,0xf0]
-; CHECK: brts just_another_label    ; encoding: [0bAAAAA110,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: just_another_label, kind: fixup_7_pcrel
-
-; BRTC
-; CHECK: brtc .+52                  ; encoding: [0xd6,0xf4]
-; CHECK: brtc .+50                  ; encoding: [0xce,0xf4]
-; CHECK: brtc end                   ; encoding: [0bAAAAA110,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
-
-; BRVS
-; CHECK: brvs .+18                  ; encoding: [0x4b,0xf0]
-; CHECK: brvs .+32                  ; encoding: [0x83,0xf0]
-; CHECK: brvs end                   ; encoding: [0bAAAAA011,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
-
-; BRVC
-; CHECK: brvc .-28                  ; encoding: [0x93,0xf7]
-; CHECK: brvc .-62                  ; encoding: [0x0b,0xf7]
-; CHECK: brvc end                   ; encoding: [0bAAAAA011,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
-
-; BRIE
-; CHECK: brie .+20                  ; encoding: [0x57,0xf0]
-; CHECK: brie .+40                  ; encoding: [0xa7,0xf0]
-; CHECK: brie end                   ; encoding: [0bAAAAA111,0b111100AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel
-
-; BRID
-; CHECK: brid .+42                  ; encoding: [0xaf,0xf4]
-; CHECK: brid .+62                  ; encoding: [0xff,0xf4]
-; CHECK: brid end                   ; encoding: [0bAAAAA111,0b111101AA]
-; CHECK:                            ;   fixup A - offset: 0, value: end, kind: fixup_7_pcrel

--- a/test/MC/AVR/inst-rcall.s
+++ b/test/MC/AVR/inst-rcall.s
@@ -8,7 +8,12 @@ foo:
   rcall  .+12
   rcall  .+46
 
-; CHECK: rcall  .+0                   ; encoding: [0x00,0xd0]
-; CHECK: rcall  .-8                   ; encoding: [0xfc,0xdf]
-; CHECK: rcall  .+12                  ; encoding: [0x06,0xd0]
-; CHECK: rcall  .+46                  ; encoding: [0x17,0xd0]
+; CHECK: rcall  .Ltmp0+0             ; encoding: [A,0b1101AAAA]
+; CHECK:                             ;   fixup A - offset: 0, value: .Ltmp0+0, kind: fixup_13_pcrel
+; CHECK: rcall  .Ltmp1-8             ; encoding: [A,0b1101AAAA]
+; CHECK:                             ;   fixup A - offset: 0, value: .Ltmp1-8, kind: fixup_13_pcrel
+; CHECK: rcall  .Ltmp2+12            ; encoding: [A,0b1101AAAA]
+; CHECK:                             ;   fixup A - offset: 0, value: .Ltmp2+12, kind: fixup_13_pcrel
+; CHECK: rcall  .Ltmp3+46            ; encoding: [A,0b1101AAAA]
+; CHECK:                             ;   fixup A - offset: 0, value: .Ltmp3+46, kind: fixup_13_pcrel
+

--- a/test/MC/AVR/inst-rjmp.s
+++ b/test/MC/AVR/inst-rjmp.s
@@ -13,12 +13,19 @@ end:
   rjmp .-4
   rjmp .-6
 
-; CHECK: foo:
-; CHECK: rjmp  .+2                   ; encoding: [0x01,0xc0]
-; CHECK: rjmp  .-2                   ; encoding: [0xff,0xcf]
-; CHECK: rjmp  foo                   ; encoding: [A,0b1100AAAA]
-; CHECK: rjmp  .+8                   ; encoding: [0x04,0xc0]
-; CHECK: rjmp  end                   ; encoding: [A,0b1100AAAA]
-; CHECK: rjmp  .+0                   ; encoding: [0x00,0xc0]
-; CHECJ: rjmp  .-4                   ; encoding: [0xfe,0xcf]
-; CHECK: rjmp  .-6                   ; encoding: [0xfd,0xcf]
+; CHECK: rjmp    .Ltmp0+2                ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp0+2, kind: fixup_13_pcrel
+; CHECK: rjmp    .Ltmp1-2                ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp1-2, kind: fixup_13_pcrel
+; CHECK: rjmp    foo                     ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: foo, kind: fixup_13_pcrel
+; CHECK: rjmp    .Ltmp2+8                ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp2+8, kind: fixup_13_pcrel
+; CHECK: rjmp    end                     ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: end, kind: fixup_13_pcrel
+; CHECK: rjmp    .Ltmp3+0                ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp3+0, kind: fixup_13_pcrel
+; CHECK: rjmp    .Ltmp4-4                ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp4-4, kind: fixup_13_pcrel
+; CHECK: rjmp    .Ltmp5-6                ; encoding: [A,0b1100AAAA]
+; CHECK:                                 ;   fixup A - offset: 0, value: .Ltmp5-6, kind: fixup_13_pcrel


### PR DESCRIPTION
Beforehand, if a PC-relative branch target was parsed (in `AVRAsmParser.cpp`), we threw away the `.` token and then delegated the operand parsing to LLVM.

Now, if we see the `.` token, we give it to LLVM so that it can handle the address itself. LLVM will create a temporary label for each PC-relative branch, and use that.