### PR TITLE
1-bit types consume one byte of space, not zero

### DIFF
--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -835,8 +835,8 @@ bool AVRTargetLowering::isOffsetFoldingLegal(
 static void parseFunctionArgs(const Function *F, const DataLayout *TD,
                               SmallVectorImpl<unsigned> &Out) {
   for (Argument const &Arg : F->args()) {
-    unsigned Bytes = TD->getTypeSizeInBits(Arg.getType()) / 8;
-    Out.push_back(((Bytes == 1) || (Bytes == 2)) ? 1 : Bytes / 2);
+    unsigned Bytes = (TD->getTypeSizeInBits(Arg.getType()) + 7) / 8;
+    Out.push_back((Bytes + 1) / 2);
   }
 }
 

--- a/test/CodeGen/AVR/lower-formal-arguments-assertion.ll
+++ b/test/CodeGen/AVR/lower-formal-arguments-assertion.ll
@@ -1,14 +1,7 @@
 ; RUN: llc < %s -march=avr | FileCheck %s
-; XFAIL:
-
-; Test case for an assertion error.
-; 
-; Error:
-; ```
-; "LowerFormalArguments didn't emit the correct number of values!"
-; ```
-; in `lib/CodeGen/SelectionDAG/SelectionDAGBuilder.cpp`
 
 define void @foo(i1) {
+; CHECK-LABEL: foo:
+; CHECK: ret
   ret void
 }


### PR DESCRIPTION
Integer division was rounding off `i1` to take 0 bytes.

Closes #173