### PR TITLE
[AVR] Fix uninitialized MRI in AVRAsmPrinter

### DIFF
--- a/lib/Target/AVR/AVRAsmPrinter.cpp
+++ b/lib/Target/AVR/AVRAsmPrinter.cpp
@@ -39,12 +39,14 @@ namespace llvm {
  * An assembly code printer.
  */
 class AVRAsmPrinter : public AsmPrinter {
-  MCRegisterInfo MRI;
+  const MCRegisterInfo *MRI;
 
 public:
   explicit AVRAsmPrinter(TargetMachine &TM,
                          std::unique_ptr<MCStreamer> Streamer)
-      : AsmPrinter(TM, std::move(Streamer)) {}
+      : AsmPrinter(TM, std::move(Streamer)) {
+    MRI = TM.getMCRegisterInfo();
+  }
 
   const char *getPassName() const override { return "AVR Assembly Printer"; }
 
@@ -69,7 +71,7 @@ void AVRAsmPrinter::printOperand(const MachineInstr *MI, unsigned OpNo,
 
   switch (MO.getType()) {
   case MachineOperand::MO_Register:
-    O << AVRInstPrinter::getPrettyRegisterName(MO.getReg(), MRI);
+    O << AVRInstPrinter::getPrettyRegisterName(MO.getReg(), *MRI);
     break;
   case MachineOperand::MO_Immediate:
     O << MO.getImm();
@@ -126,7 +128,7 @@ bool AVRAsmPrinter::PrintAsmOperand(const MachineInstr *MI, unsigned OpNum,
                                                            : AVR::sub_lo);
       }
 
-      O << AVRInstPrinter::getPrettyRegisterName(Reg, MRI);
+      O << AVRInstPrinter::getPrettyRegisterName(Reg, *MRI);
       return false;
     }
   }


### PR DESCRIPTION
AVRAsmPrinter was crashing randomly for me, this fixed it.