### PR TITLE
Compile again, after tracking upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,19 @@
+dist: trusty
 language: cpp
 script: cmake
 
-matrix:
-  include:
-    - env: CLANG_VERSION=3.7 CPP=11 LIBCXX=On
-      os: linux
-      addons: *clang37
+addons:
+  apt:
+    sources:
+      - kubuntu-backports
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-5
+      - g++-5
+      - cmake
 
-# Attempt to get the right GCC/Clang versions
-before_script:
-  - sudo add-apt-repository ppa:kubuntu-ppa/backports -y
-  - sudo apt-get update -qq
-  - sudo apt-get install cmake
-  - git clone --depth=1 https://github.com/avr-llvm/clang.git tools/clang
-  - git clone --depth=1 https://github.com/avr-llvm/compiler-rt.git projects/compiler-rt
+install:
+  - export CC="gcc-5" CXX="g++-5"
 
 script:
   - mkdir build && cd build

--- a/lib/Target/AVR/AVRExpandPseudoInsts.cpp
+++ b/lib/Target/AVR/AVRExpandPseudoInsts.cpp
@@ -158,7 +158,7 @@ bool AVRExpandPseudo::expand<AVR::ADCWRdRr>(Block &MBB, BlockIt MBBI) {
     .addReg(DstHiReg, getKillRegState(DstIsKill))
     .addReg(SrcHiReg, getKillRegState(SrcIsKill));
 
-  if (ImpIsDead) { MIBHI->getOperand(3).setIsDead() }
+  if (ImpIsDead) { MIBHI->getOperand(3).setIsDead(); }
 
   // SREG is always implicitly killed
   MIBHI->getOperand(4).setIsKill();

--- a/lib/Target/AVR/AVRFrameLowering.cpp
+++ b/lib/Target/AVR/AVRFrameLowering.cpp
@@ -355,7 +355,7 @@ static void fixStackStores(MachineBasicBlock &MBB,
   }
 }
 
-void AVRFrameLowering::eliminateCallFramePseudoInstr(
+MachineBasicBlock::iterator AVRFrameLowering::eliminateCallFramePseudoInstr(
     MachineFunction &MF, MachineBasicBlock &MBB,
     MachineBasicBlock::iterator MI) const {
   const AVRTargetMachine &TM = (const AVRTargetMachine &)MF.getTarget();
@@ -368,8 +368,7 @@ void AVRFrameLowering::eliminateCallFramePseudoInstr(
   // with real store instructions.
   if (TFI->hasReservedCallFrame(MF)) {
     fixStackStores(MBB, MI, TII, false);
-    MBB.erase(MI);
-    return;
+    return MBB.erase(MI);
   }
 
   DebugLoc dl = MI->getDebugLoc();
@@ -410,7 +409,7 @@ void AVRFrameLowering::eliminateCallFramePseudoInstr(
     }
   }
 
-  MBB.erase(MI);
+  return MBB.erase(MI);
 }
 
 void AVRFrameLowering::determineCalleeSaves(MachineFunction &MF,

--- a/lib/Target/AVR/AVRFrameLowering.h
+++ b/lib/Target/AVR/AVRFrameLowering.h
@@ -38,7 +38,7 @@ public:
   bool canSimplifyCallFramePseudos(const MachineFunction &MF) const override;
   void determineCalleeSaves(MachineFunction &MF, BitVector &SavedRegs,
                             RegScavenger *RS = nullptr) const override;
-  void
+  MachineBasicBlock::iterator
   eliminateCallFramePseudoInstr(MachineFunction &MF, MachineBasicBlock &MBB,
                                 MachineBasicBlock::iterator MI) const override;
 };

--- a/lib/Target/AVR/AVRISelDAGToDAG.cpp
+++ b/lib/Target/AVR/AVRISelDAGToDAG.cpp
@@ -53,7 +53,7 @@ public:
 #include "AVRGenDAGISel.inc"
 
 private:
-  SDNode *Select(SDNode *N) override;
+  SDNode *SelectImpl(SDNode *N) override;
 
   template <unsigned NodeType> SDNode *select(SDNode *N);
   SDNode *selectMultiplication(SDNode *N);
@@ -505,7 +505,7 @@ SDNode *AVRDAGToDAGISel::selectMultiplication(llvm::SDNode *N) {
   return nullptr;
 }
 
-SDNode *AVRDAGToDAGISel::Select(SDNode *N) {
+SDNode *AVRDAGToDAGISel::SelectImpl(SDNode *N) {
   unsigned Opcode = N->getOpcode();
   SDLoc DL(N);
 

--- a/lib/Target/AVR/AVRISelLowering.cpp
+++ b/lib/Target/AVR/AVRISelLowering.cpp
@@ -214,7 +214,7 @@ const char *AVRTargetLowering::getTargetNodeName(unsigned Opcode) const {
     NODE(RET_FLAG);
     NODE(RETI_FLAG);
     NODE(CALL);
-    NODE(Wrapper);
+    NODE(WRAPPER);
     NODE(LSL);
     NODE(LSR);
     NODE(ROL);
@@ -353,7 +353,7 @@ SDValue AVRTargetLowering::LowerGlobalAddress(SDValue Op,
   // Create the TargetGlobalAddress node, folding in the constant offset.
   SDValue Result =
       DAG.getTargetGlobalAddress(GV, SDLoc(Op), getPointerTy(DL), Offset);
-  return DAG.getNode(AVRISD::Wrapper, SDLoc(Op), getPointerTy(DL), Result);
+  return DAG.getNode(AVRISD::WRAPPER, SDLoc(Op), getPointerTy(DL), Result);
 }
 
 SDValue AVRTargetLowering::LowerBlockAddress(SDValue Op,
@@ -363,7 +363,7 @@ SDValue AVRTargetLowering::LowerBlockAddress(SDValue Op,
 
   SDValue Result = DAG.getTargetBlockAddress(BA, getPointerTy(DL));
 
-  return DAG.getNode(AVRISD::Wrapper, SDLoc(Op), getPointerTy(DL), Result);
+  return DAG.getNode(AVRISD::WRAPPER, SDLoc(Op), getPointerTy(DL), Result);
 }
 
 /// IntCCToAVRCC - Convert a DAG integer condition code to an AVR CC.

--- a/lib/Target/AVR/AVRTargetMachine.cpp
+++ b/lib/Target/AVR/AVRTargetMachine.cpp
@@ -25,7 +25,7 @@
 namespace llvm {
 
 /// Processes a CPU name.
-static StringRef getTargetCPU(StringRef CPU) {
+static StringRef getCPU(StringRef CPU) {
   if (CPU.empty() || CPU == "generic") {
     return "avr2";
   }
@@ -40,8 +40,8 @@ AVRTargetMachine::AVRTargetMachine(const Target &T, const Triple &TT,
                                    CodeGenOpt::Level OL)
     : LLVMTargetMachine(
           T, "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-i64:8:8-f32:8:8-f64:8:8-n8", TT,
-          getTargetCPU(CPU), FS, Options, RM, CM, OL),
-      SubTarget(TT, GetTargetCPU(CPU), FS, *this) {
+          getCPU(CPU), FS, Options, RM, CM, OL),
+      SubTarget(TT, getCPU(CPU), FS, *this) {
   this->TLOF = make_unique<AVRTargetObjectFile>();
   initAsmInfo();
 }

--- a/test/CodeGen/AVR/calling-conv-assertion.ll
+++ b/test/CodeGen/AVR/calling-conv-assertion.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=avr | FileCheck %s
-; XFAIL:
+; XFAIL: *
 
 ; Test case for an assertion error.
 ;

--- a/test/CodeGen/AVR/impossible-reg-to-reg-copy.ll
+++ b/test/CodeGen/AVR/impossible-reg-to-reg-copy.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=avr | FileCheck %s
-; XFAIL:
+; XFAIL: *
 
 ; Test case for an assertion error.
 ;
@@ -23,4 +23,3 @@ next:                                             ; preds = %entry-block
 cond:                                             ; preds = %entry-block
   unreachable
 }
-

--- a/test/CodeGen/AVR/issue-cannot-select-mulhs.ll
+++ b/test/CodeGen/AVR/issue-cannot-select-mulhs.ll
@@ -1,5 +1,5 @@
 ; RUN: llc < %s -march=avr | FileCheck %s
-; XFAIL:
+; XFAIL: *
 
 define fastcc void @foo(i32) unnamed_addr {
 ; CHECK-LABEL: foo:


### PR DESCRIPTION
We should probably look closer at 9ed38db20eac20ba78c7daf6970324612cd0d60f to see if we can follow those changes closely.