### PR TITLE
Allow relocatable expressions in more places

### DIFF
--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -186,6 +186,12 @@ def imm16 : Operand<i16>
     let EncoderMethod = "encodeImm<AVR::fixup_16>";
 }
 
+/// A 6-bit immediate used in the ADIW/SBIW instructions.
+def arith_imm6 : Operand<i16>
+{
+    let EncoderMethod = "encodeImm<AVR::fixup_6_adiw>";
+}
+
 // Addressing mode pattern reg+imm6
 def addr : ComplexPattern<iPTR, 2, "SelectAddr", [], [SDNPWantRoot]>;
 
@@ -378,7 +384,7 @@ Defs = [SREG] in
   // Adds an immediate 6-bit value K to Rd, placing the result in Rd.
   def ADIWRdK : FWRdK<0b0,
                       (outs IWREGS:$rd),
-                      (ins IWREGS:$src, i16imm:$k),
+                      (ins IWREGS:$src, arith_imm6:$k),
                       "adiw\t$rd, $k",
                       [(set i16:$rd, (add i16:$src, uimm6:$k)),
                        (implicit SREG)]>,
@@ -433,7 +439,7 @@ Defs = [SREG] in
 
   def SBIWRdK : FWRdK<0b1,
                       (outs IWREGS:$rd),
-                      (ins IWREGS:$src, i16imm:$k),
+                      (ins IWREGS:$src, arith_imm6:$k),
                       "sbiw\t$rd, $k",
                       [(set i16:$rd, (sub i16:$src, uimm6:$k)),
                        (implicit SREG)]>,

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -155,7 +155,7 @@ def memspi : Operand<iPTR>
   let MIOperandInfo = (ops GPRSP, i16imm);
 }
 
-def i8imm_com : Operand<i8>
+def imm_com8 : Operand<i8>
 {
   let EncoderMethod = "encodeComplement";
 
@@ -187,7 +187,7 @@ def imm16 : Operand<i16>
 }
 
 /// A 6-bit immediate used in the ADIW/SBIW instructions.
-def arith_imm6 : Operand<i16>
+def imm_arith6 : Operand<i16>
 {
     let EncoderMethod = "encodeImm<AVR::fixup_6_adiw>";
 }
@@ -404,7 +404,7 @@ Defs = [SREG] in
   // Adds an immediate 6-bit value K to Rd, placing the result in Rd.
   def ADIWRdK : FWRdK<0b0,
                       (outs IWREGS:$rd),
-                      (ins IWREGS:$src, arith_imm6:$k),
+                      (ins IWREGS:$src, imm_arith6:$k),
                       "adiw\t$rd, $k",
                       [(set i16:$rd, (add i16:$src, uimm6:$k)),
                        (implicit SREG)]>,
@@ -459,7 +459,7 @@ Defs = [SREG] in
 
   def SBIWRdK : FWRdK<0b1,
                       (outs IWREGS:$rd),
-                      (ins IWREGS:$src, arith_imm6:$k),
+                      (ins IWREGS:$src, imm_arith6:$k),
                       "sbiw\t$rd, $k",
                       [(set i16:$rd, (sub i16:$src, uimm6:$k)),
                        (implicit SREG)]>,
@@ -1692,7 +1692,7 @@ Defs = [SREG] in
   // imm_ldi8 encoder. This will cause no fixups to be created on this instruction.
   def CBRRdK : FRdK<0b0111,
                     (outs LD8:$rd),
-                    (ins LD8:$src, i8imm_com:$k),
+                    (ins LD8:$src, imm_com8:$k),
                     "cbr\t$rd, $k",
                     []>;
 }

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -205,6 +205,13 @@ def imm_port5 : Operand<i8>
     let EncoderMethod = "encodeImm<AVR::fixup_port5>";
 }
 
+/// A 6-bit port number used in the `IN` instruction and friends (the
+/// `FIORdA` format.
+def imm_port6 : Operand<i8>
+{
+    let EncoderMethod = "encodeImm<AVR::fixup_port6>";
+}
+
 // Addressing mode pattern reg+imm6
 def addr : ComplexPattern<iPTR, 2, "SelectAddr", [], [SDNPWantRoot]>;
 
@@ -1459,7 +1466,7 @@ let canFoldAsLoad = 1,
 isReMaterializable = 1 in
 {
   def INRdA : FIORdA<(outs GPR8:$dst),
-                     (ins i16imm:$src),
+                     (ins imm_port6:$src),
                      "in\t$dst, $src",
                      [(set i8:$dst, (load ioaddr8:$src))]>;
 
@@ -1471,7 +1478,7 @@ isReMaterializable = 1 in
 
 // Write data to IO location operations.
 def OUTARr : FIOARr<(outs),
-                    (ins i16imm:$dst, GPR8:$src),
+                    (ins imm_port6:$dst, GPR8:$src),
                     "out\t$dst, $src",
                     [(store i8:$src, ioaddr8:$dst)]>;
 

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -192,6 +192,13 @@ def arith_imm6 : Operand<i16>
     let EncoderMethod = "encodeImm<AVR::fixup_6_adiw>";
 }
 
+/// An 8-bit immediate inside an instruction with the same format
+/// as the `LDI` instruction (the `FRdK` format).
+def imm_ldi8 : Operand<i8>
+{
+    let EncoderMethod = "encodeImm<AVR::fixup_ldi>";
+}
+
 // Addressing mode pattern reg+imm6
 def addr : ComplexPattern<iPTR, 2, "SelectAddr", [], [SDNPWantRoot]>;
 
@@ -421,7 +428,7 @@ Defs = [SREG] in
 
   def SUBIRdK : FRdK<0b0101,
                      (outs LD8:$rd),
-                     (ins LD8:$src, i8imm:$k),
+                     (ins LD8:$src, imm_ldi8:$k),
                      "subi\t$rd, $k",
                      [(set i8:$rd, (sub i8:$src, imm:$k)),
                       (implicit SREG)]>;
@@ -469,7 +476,7 @@ Defs = [SREG] in
 
     def SBCIRdK : FRdK<0b0100,
                        (outs LD8:$rd),
-                       (ins LD8:$src, i8imm:$k),
+                       (ins LD8:$src, imm_ldi8:$k),
                        "sbci\t$rd, $k",
                        [(set i8:$rd, (sube i8:$src, imm:$k)),
                         (implicit SREG)]>;
@@ -638,7 +645,7 @@ Defs = [SREG] in
 
   def ANDIRdK : FRdK<0b0111,
                      (outs LD8:$rd),
-                     (ins LD8:$src, i8imm:$k),
+                     (ins LD8:$src, imm_ldi8:$k),
                      "andi\t$rd, $k",
                      [(set i8:$rd, (and i8:$src, imm:$k)),
                       (implicit SREG)]>;
@@ -656,7 +663,7 @@ Defs = [SREG] in
 
   def ORIRdK : FRdK<0b0110,
                     (outs LD8:$rd),
-                    (ins LD8:$src, i8imm:$k),
+                    (ins LD8:$src, imm_ldi8:$k),
                     "ori\t$rd, $k",
                     [(set i8:$rd, (or i8:$src, imm:$k)),
                      (implicit SREG)]>;
@@ -883,7 +890,7 @@ let Defs = [SREG] in
   let Uses = [SREG] in
   def CPIRdK : FRdK<0b0011,
                     (outs),
-                    (ins GPR8:$rd, i8imm:$k),
+                    (ins GPR8:$rd, imm_ldi8:$k),
                     "cpi\t$rd, $k",
                     [(AVRcmp i8:$rd, imm:$k), (implicit SREG)]>;
 }
@@ -1077,7 +1084,7 @@ let isReMaterializable = 1 in
 {
   def LDIRdK : FRdK<0b1110,
                     (outs LD8:$rd),
-                    (ins i8imm:$k),
+                    (ins imm_ldi8:$k),
                     "ldi\t$rd, $k",
                     [(set i8:$rd, imm:$k)]>;
 
@@ -1660,13 +1667,15 @@ Defs = [SREG] in
   // Alias for ORI Rd, K
   def SBRRdK : FRdK<0b0110,
                     (outs LD8:$rd),
-                    (ins LD8:$src, i8imm:$k),
+                    (ins LD8:$src, imm_ldi8:$k),
                     "sbr\t$rd, $k",
                     [(set i8:$rd, (or i8:$src, imm:$k)),
                      (implicit SREG)]>;
 
   // CBR Rd, K
   // Alias for `ANDI Rd, COM(K)` where COM(K) is the compliment of K.
+  // FIXME: This uses the 'complement' encoder. We need it to also use the
+  // imm_ldi8 encoder. This will cause no fixups to be created on this instruction.
   def CBRRdK : FRdK<0b0111,
                     (outs LD8:$rd),
                     (ins LD8:$src, i8imm_com:$k),

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -199,6 +199,12 @@ def imm_ldi8 : Operand<i8>
     let EncoderMethod = "encodeImm<AVR::fixup_ldi>";
 }
 
+/// A 5-bit port number used in SBIC and friends (the `FIOBIT` format).
+def imm_port5 : Operand<i8>
+{
+    let EncoderMethod = "encodeImm<AVR::fixup_port5>";
+}
+
 // Addressing mode pattern reg+imm6
 def addr : ComplexPattern<iPTR, 2, "SelectAddr", [], [SDNPWantRoot]>;
 
@@ -919,13 +925,13 @@ isTerminator = 1 in
 
     def SBICAb : FIOBIT<0b01,
                         (outs),
-                        (ins i16imm:$a, i8imm:$b),
+                        (ins imm_port5:$a, i8imm:$b),
                         "sbic\t$a, $b",
                         []>;
 
     def SBISAb : FIOBIT<0b11,
                         (outs),
-                        (ins i16imm:$a, i8imm:$b),
+                        (ins imm_port5:$a, i8imm:$b),
                         "sbis\t$a, $b",
                         []>;
   }
@@ -1632,14 +1638,14 @@ def SWAPRd : FRd<0b1001,
 // instead of in+ori+out which requires one more instr.
 def SBIAb : FIOBIT<0b10,
                    (outs),
-                   (ins i16imm:$addr, i8imm:$bit),
+                   (ins imm_port5:$addr, i8imm:$bit),
                    "sbi\t$addr, $bit",
                    [(store (or (i8 (load lowioaddr8:$addr)), iobitpos8:$bit),
                      lowioaddr8:$addr)]>;
 
 def CBIAb : FIOBIT<0b00,
                    (outs),
-                   (ins i16imm:$addr, i8imm:$bit),
+                   (ins imm_port5:$addr, i8imm:$bit),
                    "cbi\t$addr, $bit",
                    [(store (and (i8 (load lowioaddr8:$addr)), iobitposn8:$bit),
                      lowioaddr8:$addr)]>;

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -1279,6 +1279,7 @@ let Constraints = "$ptrreg = $base_wb,@earlyclobber $base_wb" in
   // ST P+, Rr
   // Stores the value of Rr into the location addressed by pointer P.
   // Post increments P.
+  // FIXME: what is `$offs` and is it needed?
   def STPtrPiRr : FSTLD<1,
                         0b01,
                         (outs LDSTPtrReg:$base_wb),

--- a/lib/Target/AVR/AVRInstrInfo.td
+++ b/lib/Target/AVR/AVRInstrInfo.td
@@ -183,7 +183,7 @@ def call_target : Operand<iPTR>
 // A 16-bit address (which can lead to an R_AVR_16 relocation).
 def imm16 : Operand<i16>
 {
-    let EncoderMethod = "encodeImm16";
+    let EncoderMethod = "encodeImm<AVR::fixup_16>";
 }
 
 // Addressing mode pattern reg+imm6

--- a/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
+++ b/lib/Target/AVR/InstPrinter/AVRInstPrinter.cpp
@@ -141,22 +141,27 @@ void AVRInstPrinter::printPCRelImm(const MCInst *MI, unsigned OpNo,
 void AVRInstPrinter::printMemri(const MCInst *MI, unsigned OpNo,
                                 raw_ostream &O) {
   const MCOperand &RegOp = MI->getOperand(OpNo);
-  const MCOperand &ImmOp = MI->getOperand(OpNo + 1);
+  const MCOperand &OffsetOp = MI->getOperand(OpNo + 1);
 
   assert(RegOp.isReg() && "Expected a register");
-  assert(ImmOp.isImm() && "Expected an immediate value");
 
   // Print the register.
   printOperand(MI, OpNo, O);
 
-  // Print the immediate.
+  // Print the offset.
   {
-    auto Imm = ImmOp.getImm();
+    if (OffsetOp.isImm()) {
+      auto Offset = OffsetOp.getImm();
 
-    if (Imm >= 0)
-      O << '+';
+      if (Offset >= 0)
+        O << '+';
 
-    O << Imm;
+      O << Offset;
+    } else if (OffsetOp.isExpr()) {
+      O << *OffsetOp.getExpr();
+    } else {
+      llvm_unreachable("unknown type for offset");
+    }
   }
 }
 

--- a/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
@@ -306,7 +306,7 @@ MCFixupKindInfo const &AVRAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
 
       {"fixup_call", 0, 22, 0},
 
-      {"fixup_6", 0, 16, 0}, // non-contignous
+      {"fixup_6", 0, 16, 0}, // non-contiguous
       {"fixup_6_adiw", 0, 6, 0},
 
       {"fixup_lo8_ldi_gs", 0, 8, 0},
@@ -322,7 +322,7 @@ MCFixupKindInfo const &AVRAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
 
       {"fixup_lds_sts_16", 0, 16, 0},
 
-      {"fixup_port6", 0, 6, 0},
+      {"fixup_port6", 0, 16, 0}, // non-contiguous
       {"fixup_port5", 3, 5, 0},
 
   };

--- a/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
@@ -223,6 +223,7 @@ void AVRAsmBackend::adjustFixupValue(const MCFixup &Fixup, uint64_t &Value,
 
   // AVR fixups that don't need to be adjusted.
   case AVR::fixup_16:
+  case AVR::fixup_port5:
     break;
 
   case FK_Data_2:
@@ -320,7 +321,7 @@ MCFixupKindInfo const &AVRAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
       {"fixup_lds_sts_16", 0, 16, 0},
 
       {"fixup_port6", 0, 6, 0},
-      {"fixup_port5", 0, 5, 0},
+      {"fixup_port5", 3, 5, 0},
 
   };
 

--- a/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRAsmBackend.cpp
@@ -269,6 +269,8 @@ void AVRAsmBackend::applyFixup(const MCFixup &Fixup, char *Data,
 }
 
 MCFixupKindInfo const &AVRAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
+  // NOTE: Many AVR fixups are non-contignous. We work around this by
+  // saying that the fixup is the size of the entire instruction (16 or 32 bits).
   const static MCFixupKindInfo Infos[AVR::NumTargetFixupKinds] = {
       // This table *must* be in same the order of fixup_* kinds in
       // AVRFixupKinds.h.
@@ -304,7 +306,7 @@ MCFixupKindInfo const &AVRAsmBackend::getFixupKindInfo(MCFixupKind Kind) const {
 
       {"fixup_call", 0, 22, 0},
 
-      {"fixup_6", 0, 6, 0},
+      {"fixup_6", 0, 16, 0}, // non-contignous
       {"fixup_6_adiw", 0, 6, 0},
 
       {"fixup_lo8_ldi_gs", 0, 8, 0},

--- a/lib/Target/AVR/MCTargetDesc/AVRMCCodeEmitter.cpp
+++ b/lib/Target/AVR/MCTargetDesc/AVRMCCodeEmitter.cpp
@@ -178,13 +178,14 @@ unsigned AVRMCCodeEmitter::encodeComplement(const MCInst &MI, unsigned OpNo,
   return (~0) - imm;
 }
 
-unsigned AVRMCCodeEmitter::encodeImm16(const MCInst &MI, unsigned OpNo,
-                                       SmallVectorImpl<MCFixup> &Fixups,
-                                       const MCSubtargetInfo &STI) const {
+template <AVR::Fixups Fixup>
+unsigned AVRMCCodeEmitter::encodeImm(const MCInst &MI, unsigned OpNo,
+                                     SmallVectorImpl<MCFixup> &Fixups,
+                                     const MCSubtargetInfo &STI) const {
   auto MO = MI.getOperand(OpNo);
 
   if (MO.isExpr()) {
-    MCFixupKind FixupKind = static_cast<MCFixupKind>(AVR::fixup_16);
+    MCFixupKind FixupKind = static_cast<MCFixupKind>(Fixup);
     Fixups.push_back(MCFixup::create(0, MO.getExpr(), FixupKind, MI.getLoc()));
     return 0;
   }

--- a/lib/Target/AVR/MCTargetDesc/AVRMCCodeEmitter.h
+++ b/lib/Target/AVR/MCTargetDesc/AVRMCCodeEmitter.h
@@ -67,10 +67,10 @@ private:
                             SmallVectorImpl<MCFixup> &Fixups,
                             const MCSubtargetInfo &STI) const;
 
-  /// Encodes a 16-bit address.
-  unsigned encodeImm16(const MCInst &MI, unsigned OpNo,
-                       SmallVectorImpl<MCFixup> &Fixups,
-                       const MCSubtargetInfo &STI) const;
+  template <AVR::Fixups Fixup>
+  unsigned encodeImm(const MCInst &MI, unsigned OpNo,
+                     SmallVectorImpl<MCFixup> &Fixups,
+                     const MCSubtargetInfo &STI) const;
 
   /// Gets the encoding of the target for the `CALL k` instruction.
   unsigned encodeCallTarget(const MCInst &MI, unsigned OpNo,

--- a/test/MC/AVR/inst-adiw.s
+++ b/test/MC/AVR/inst-adiw.s
@@ -12,11 +12,17 @@ foo:
   adiw r30,  63
   adiw r30,  3
 
+  adiw r24, SYMBOL
+
 ; CHECK: adiw r26,  12               ; encoding: [0x1c,0x96]
-; CHECK: adiw r26,   63               ; encoding: [0xdf,0x96]
+; CHECK: adiw r26,  63               ; encoding: [0xdf,0x96]
 
 ; CHECK: adiw r28,  17               ; encoding: [0x61,0x96]
 ; CHECK: adiw r28,  0                ; encoding: [0x20,0x96]
 
 ; CHECK: adiw r30,  63               ; encoding: [0xff,0x96]
 ; CHECK: adiw r30,  3                ; encoding: [0x33,0x96]
+
+; CHECK: adiw r24, SYMBOL            ; encoding: [0b00AAAAAA,0x96]
+                                     ;   fixup A - offset: 0, value: SYMBOL, kind: fixup_6_adiw
+

--- a/test/MC/AVR/inst-andi.s
+++ b/test/MC/AVR/inst-andi.s
@@ -7,8 +7,14 @@ foo:
   andi r29, 190
   andi r22, 172
   andi r27, 92
+
+  andi r20, BAR
   
 ; CHECK: andi r16, 255                 ; encoding: [0x0f,0x7f]
 ; CHECK: andi r29, 190                 ; encoding: [0xde,0x7b]
 ; CHECK: andi r22, 172                 ; encoding: [0x6c,0x7a]
 ; CHECK: andi r27, 92                  ; encoding: [0xbc,0x75]
+
+; CHECK: andi r20, BAR                 ; encoding: [0x40'A',0x70]
+; CHECK:                               ;   fixup A - offset: 0, value: BAR, kind: fixup_ldi
+

--- a/test/MC/AVR/inst-cbi.s
+++ b/test/MC/AVR/inst-cbi.s
@@ -8,7 +8,13 @@ foo:
   cbi 0, 0
   cbi 7, 2
 
+  cbi bar-2, 2
+
 ; CHECK: cbi 3, 5                  ; encoding: [0x1d,0x98]
 ; CHECK: cbi 1, 1                  ; encoding: [0x09,0x98]
 ; CHECK: cbi 0, 0                  ; encoding: [0x00,0x98]
 ; CHECK: cbi 7, 2                  ; encoding: [0x3a,0x98]
+
+; CHECK: cbi bar-2, 2              ; encoding: [0bAAAAA010,0x98]
+; CHECK:                           ;   fixup A - offset: 0, value: bar-2, kind: fixup_port5
+

--- a/test/MC/AVR/inst-cpi.s
+++ b/test/MC/AVR/inst-cpi.s
@@ -7,8 +7,14 @@ foo:
   cpi r29, 190
   cpi r22, 172
   cpi r27, 92
+
+  cpi r21, ear
   
 ; CHECK: cpi r16, 241                  ; encoding: [0x01,0x3f]
 ; CHECK: cpi r29, 190                  ; encoding: [0xde,0x3b]
 ; CHECK: cpi r22, 172                  ; encoding: [0x6c,0x3a]
 ; CHECK: cpi r27, 92                   ; encoding: [0xbc,0x35]
+
+; CHECK: cpi r21, ear                  ; encoding: [0x50'A',0x30]
+; CHECK:                               ;   fixup A - offset: 0, value: ear, kind: fixup_ldi
+

--- a/test/MC/AVR/inst-in.s
+++ b/test/MC/AVR/inst-in.s
@@ -8,7 +8,13 @@ foo:
   in r5, 32
   in r0, 0
 
+  in r20, foo+1
+
 ; CHECK: in r2, 4                   ; encoding: [0x24,0xb0]
 ; CHECK: in r9, 6                   ; encoding: [0x96,0xb0]
 ; CHECK: in r5, 32                  ; encoding: [0x50,0xb4]
 ; CHECK: in r0, 0                   ; encoding: [0x00,0xb0]
+
+; CHECK: in r20, foo+1              ; encoding: [0x40'A',0xb1'A']
+; CHECK:                            ;   fixup A - offset: 0, value: foo+1, kind: fixup_port6
+

--- a/test/MC/AVR/inst-jmp.s
+++ b/test/MC/AVR/inst-jmp.s
@@ -8,7 +8,13 @@ foo:
   jmp   80
   jmp   0
 
+  jmp foo+1
+
 ; CHECK: jmp  200                  ; encoding: [0x0c,0x94,0x64,0x00]
 ; CHECK: jmp -12                   ; encoding: [0xfd,0x95,0xfa,0xff]
 ; CHECK: jmp  80                   ; encoding: [0x0c,0x94,0x28,0x00]
 ; CHECK: jmp  0                    ; encoding: [0x0c,0x94,0x00,0x00]
+
+; CHECK: jmp foo+1                 ; encoding: [0x0c'A',0x94'A',0b00AAAAAA,0x00]
+; CHECK:                           ;   fixup A - offset: 0, value: foo+1, kind: fixup_call
+

--- a/test/MC/AVR/inst-ldd.s
+++ b/test/MC/AVR/inst-ldd.s
@@ -9,8 +9,14 @@ foo:
   ldd r9, Z+12 
   ldd r7, Z+30
 
+  ldd r9, Z+foo
+
 ; CHECK: ldd r2, Y+2                  ; encoding: [0x2a,0x80]
 ; CHECK: ldd r0, Y+0                  ; encoding: [0x08,0x80]
                      
 ; CHECK: ldd r9, Z+12                 ; encoding: [0x94,0x84]
 ; CHECK: ldd r7, Z+30                 ; encoding: [0x76,0x8c]
+
+; CHECK: ldd r9, Z+foo                ; encoding: [0x90'A',0x80'A']
+; CHECK:                              ;   fixup A - offset: 0, value: +foo, kind: fixup_6
+

--- a/test/MC/AVR/inst-ldi.s
+++ b/test/MC/AVR/inst-ldi.s
@@ -7,8 +7,13 @@ foo:
   ldi r29, 190
   ldi r22, 172
   ldi r27, 92
+  ldi r21, SYMBOL+3
   
 ; CHECK: ldi r16, 241                 ; encoding: [0x01,0xef]
 ; CHECK: ldi r29, 190                 ; encoding: [0xde,0xeb]
 ; CHECK: ldi r22, 172                 ; encoding: [0x6c,0xea]
 ; CHECK: ldi r27, 92                  ; encoding: [0xbc,0xe5]
+
+; CHECK: ldi r21, SYMBOL+3            ; encoding: [0x50'A',0xe0]
+; CHECK:                              ;   fixup A - offset: 0, value: SYMBOL+3, kind: fixup_ldi
+

--- a/test/MC/AVR/inst-ori.s
+++ b/test/MC/AVR/inst-ori.s
@@ -7,8 +7,14 @@ foo:
   ori r24, 190
   ori r20, 173
   ori r31, 0
+
+  ori r16, FOOBAR
   
 ; CHECK: ori r17, 208           ; encoding: [0x10,0x6d]
 ; CHECK: ori r24, 190           ; encoding: [0x8e,0x6b]
 ; CHECK: ori r20, 173           ; encoding: [0x4d,0x6a]
 ; CHECK: ori r31, 0             ; encoding: [0xf0,0x60]
+
+; CHECK: ori r16, FOOBAR        ; encoding: [A,0x60]
+; CHECK:                        ;   fixup A - offset: 0, value: FOOBAR, kind: fixup_ldi
+

--- a/test/MC/AVR/inst-out.s
+++ b/test/MC/AVR/inst-out.s
@@ -8,7 +8,13 @@ foo:
   out 32, r5
   out 0,  r0
 
+  out bar-8, r29
+
 ; CHECK: out 4,  r2                  ; encoding: [0x24,0xb8]
 ; CHECK: out 6,  r9                  ; encoding: [0x96,0xb8]
 ; CHECK: out 32, r5                  ; encoding: [0x50,0xbc]
 ; CHECK: out 0,  r0                  ; encoding: [0x00,0xb8]
+
+; CHECK: out bar-8, r29              ; encoding: [0xd0'A',0xb9'A']
+; CHECK:                             ;   fixup A - offset: 0, value: bar-8, kind: fixup_port6
+

--- a/test/MC/AVR/inst-sbci.s
+++ b/test/MC/AVR/inst-sbci.s
@@ -7,8 +7,13 @@ foo:
   sbci r23, 196
   sbci r30, 244
   sbci r19, 16
+  sbci r22, FOO
   
 ; CHECK: sbci r17, 21                 ; encoding: [0x15,0x41]
 ; CHECK: sbci r23, 196                ; encoding: [0x74,0x4c]
 ; CHECK: sbci r30, 244                ; encoding: [0xe4,0x4f]
 ; CHECK: sbci r19, 16                 ; encoding: [0x30,0x41]
+
+; CHECK: sbci r22, FOO                ; encoding: [0x60'A',0x40]
+; CHECK:                              ;   fixup A - offset: 0, value: FOO, kind: fixup_ldi
+

--- a/test/MC/AVR/inst-sbi.s
+++ b/test/MC/AVR/inst-sbi.s
@@ -8,7 +8,13 @@ foo:
   sbi 0, 0
   sbi 7, 2
 
+  sbi main, 0
+
 ; CHECK: sbi 3, 5                  ; encoding: [0x1d,0x9a]
 ; CHECK: sbi 1, 1                  ; encoding: [0x09,0x9a]
 ; CHECK: sbi 0, 0                  ; encoding: [0x00,0x9a]
 ; CHECK: sbi 7, 2                  ; encoding: [0x3a,0x9a]
+
+; CHECK: sbi main, 0               ; encoding: [0bAAAAA000,0x9a]
+; CHECK:                           ;   fixup A - offset: 0, value: main, kind: fixup_port5
+

--- a/test/MC/AVR/inst-sbic.s
+++ b/test/MC/AVR/inst-sbic.s
@@ -8,7 +8,13 @@ foo:
   sbic 16, 5
   sbic 0,  0
 
+  sbic foo+1, 1
+
 ; CHECK: sbic 4,  3                  ; encoding: [0x23,0x99]
 ; CHECK: sbic 6,  2                  ; encoding: [0x32,0x99]
 ; CHECK: sbic 16, 5                  ; encoding: [0x85,0x99]
 ; CHECK: sbic 0,  0                  ; encoding: [0x00,0x99]
+
+; CHECK: sbic foo+1, 1               ; encoding: [0bAAAAA001,0x99]
+; CHECK:                             ;   fixup A - offset: 0, value: foo+1, kind: fixup_port5
+

--- a/test/MC/AVR/inst-sbis.s
+++ b/test/MC/AVR/inst-sbis.s
@@ -8,7 +8,13 @@ foo:
   sbis 16, 5
   sbis 0,  0
 
+  sbis FOO+4, 7
+
 ; CHECK: sbis 4,  3                  ; encoding: [0x23,0x9b]
 ; CHECK: sbis 6,  2                  ; encoding: [0x32,0x9b]
 ; CHECK: sbis 16, 5                  ; encoding: [0x85,0x9b]
 ; CHECK: sbis 0,  0                  ; encoding: [0x00,0x9b]
+
+; CHECK: sbis FOO+4, 7               ; encoding: [0bAAAAA111,0x9b]
+; CHECK:                             ;   fixup A - offset: 0, value: FOO+4, kind: fixup_port5
+

--- a/test/MC/AVR/inst-sbiw.s
+++ b/test/MC/AVR/inst-sbiw.s
@@ -15,6 +15,8 @@ foo:
   sbiw r24, 1
   sbiw r24, 2
 
+  sbiw r24, SYMBOL-1
+
 ; CHECK: sbiw r26,  54                 ; encoding: [0xd6,0x97]
 ; CHECK: sbiw r26,  63                 ; encoding: [0xdf,0x97]
 
@@ -26,3 +28,7 @@ foo:
 
 ; CHECK: sbiw r24,  1                  ; encoding: [0x01,0x97]
 ; CHECK: sbiw r24,  2                  ; encoding: [0x02,0x97]
+
+; CHECK: sbiw    r24, SYMBOL-1         ; encoding: [0b00AAAAAA,0x97]
+                                       ;   fixup A - offset: 0, value: SYMBOL-1, kind: fixup_6_adiw
+

--- a/test/MC/AVR/inst-sbr.s
+++ b/test/MC/AVR/inst-sbr.s
@@ -7,8 +7,14 @@ foo:
   sbr r24, 190
   sbr r20, 173
   sbr r31, 0
+
+  sbr r19, _start
   
 ; CHECK: sbr r17, 208                  ; encoding: [0x10,0x6d]
 ; CHECK: sbr r24, 190                  ; encoding: [0x8e,0x6b]
 ; CHECK: sbr r20, 173                  ; encoding: [0x4d,0x6a]
 ; CHECK: sbr r31, 0                    ; encoding: [0xf0,0x60]
+
+; CHECK: sbr     r19, _start           ; encoding: [0x30'A',0x60]
+; CHECK:                               ;   fixup A - offset: 0, value: _start, kind: fixup_ldi
+

--- a/test/MC/AVR/inst-std.s
+++ b/test/MC/AVR/inst-std.s
@@ -9,8 +9,14 @@ foo:
   std Z+12, r9
   std Z+30, r7
 
+  std Y+foo, r9
+
 ; CHECK: std Y+2,  r2                 ; encoding: [0x2a,0x82]
 ; CHECK: std Y+0,  r0                 ; encoding: [0x08,0x82]
 
 ; CHECK: std Z+12, r9                 ; encoding: [0x94,0x86]
 ; CHECK: std Z+30, r7                 ; encoding: [0x76,0x8e]
+
+; CHECK: std Y+foo, r9                ; encoding: [0x98'A',0x82'A']
+; CHECK:                              ;   fixup A - offset: 0, value: +foo, kind: fixup_6
+

--- a/test/MC/AVR/inst-subi.s
+++ b/test/MC/AVR/inst-subi.s
@@ -7,8 +7,14 @@ foo:
   subi r27, 39
   subi r31, 244
   subi r16, 144
+
+  subi r20, EXTERN_SYMBOL+0
   
 ; CHECK: subi r22, 82                  ; encoding: [0x62,0x55]
 ; CHECK: subi r27, 39                  ; encoding: [0xb7,0x52]
 ; CHECK: subi r31, 244                 ; encoding: [0xf4,0x5f]
 ; CHECK: subi r16, 144                 ; encoding: [0x00,0x59]
+
+; CHECK: subi    r20, EXTERN_SYMBOL+0  ; encoding: [0x40'A',0x50]
+; CHECK:                               ;   fixup A - offset: 0, value: EXTERN_SYMBOL+0, kind: fixup_ldi
+


### PR DESCRIPTION
It was discovered in #184 that _some_ instructions would silently ignore relocatable expressions (i.e. `SYMBOL` or `SYMBOL+4`) in place of immediates, and set them to zero.

This PR adds support for expressions to other instructions which are missing it.